### PR TITLE
feat: add pagination support for AWS API calls

### DIFF
--- a/service/ec2/service.go
+++ b/service/ec2/service.go
@@ -84,7 +84,9 @@ func (s *service) GetUnusedElasticIpAddressesInfo(ctx context.Context) ([]types.
 }
 
 func (s *service) GetUnusedEBSVolumes(ctx context.Context) ([]types.Volume, error) {
-	output, err := s.client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+	var allVolumes []types.Volume
+
+	paginator := ec2.NewDescribeVolumesPaginator(s.client, &ec2.DescribeVolumesInput{
 		Filters: []types.Filter{
 			{
 				Name:   aws.String("status"),
@@ -92,11 +94,16 @@ func (s *service) GetUnusedEBSVolumes(ctx context.Context) ([]types.Volume, erro
 			},
 		},
 	})
-	if err != nil {
-		return nil, err
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		allVolumes = append(allVolumes, output.Volumes...)
 	}
 
-	return output.Volumes, nil
+	return allVolumes, nil
 }
 
 func (s *service) GetStoppedInstancesInfo(ctx context.Context) ([]types.Instance, []types.Volume, error) {
@@ -109,31 +116,36 @@ func (s *service) GetStoppedInstancesInfo(ctx context.Context) ([]types.Instance
 		},
 	}
 
-	output, err := s.client.DescribeInstances(ctx, input)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	var stoppedInstanceVolumeIDs []string
 	var stoppedInstanceForMoreThan30Days []types.Instance
 
 	thresholdTime := time.Now().Add(-30 * 24 * time.Hour)
 
-	for _, reservation := range output.Reservations {
-		for _, instance := range reservation.Instances {
-			for _, mapping := range instance.BlockDeviceMappings {
-				if mapping.Ebs != nil {
-					stoppedInstanceVolumeIDs = append(stoppedInstanceVolumeIDs, aws.ToString(mapping.Ebs.VolumeId))
-				}
-			}
-			reason := aws.ToString(instance.StateTransitionReason)
-			stoppedAt, err := utils.ParseTransitionDate(reason)
-			if err != nil {
-				continue
-			}
+	// Use paginator to handle large numbers of instances
+	paginator := ec2.NewDescribeInstancesPaginator(s.client, input)
 
-			if stoppedAt.Before(thresholdTime) {
-				stoppedInstanceForMoreThan30Days = append(stoppedInstanceForMoreThan30Days, instance)
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for _, reservation := range output.Reservations {
+			for _, instance := range reservation.Instances {
+				for _, mapping := range instance.BlockDeviceMappings {
+					if mapping.Ebs != nil {
+						stoppedInstanceVolumeIDs = append(stoppedInstanceVolumeIDs, aws.ToString(mapping.Ebs.VolumeId))
+					}
+				}
+				reason := aws.ToString(instance.StateTransitionReason)
+				stoppedAt, err := utils.ParseTransitionDate(reason)
+				if err != nil {
+					continue
+				}
+
+				if stoppedAt.Before(thresholdTime) {
+					stoppedInstanceForMoreThan30Days = append(stoppedInstanceForMoreThan30Days, instance)
+				}
 			}
 		}
 	}
@@ -141,14 +153,18 @@ func (s *service) GetStoppedInstancesInfo(ctx context.Context) ([]types.Instance
 	var stoppedInstanceVolumes []types.Volume
 
 	if len(stoppedInstanceVolumeIDs) > 0 {
-		outputEBS, err := s.client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		// Use paginator for volumes as well (in case of many volumes)
+		volumePaginator := ec2.NewDescribeVolumesPaginator(s.client, &ec2.DescribeVolumesInput{
 			VolumeIds: stoppedInstanceVolumeIDs,
 		})
-		if err != nil {
-			return nil, nil, err
-		}
 
-		stoppedInstanceVolumes = outputEBS.Volumes
+		for volumePaginator.HasMorePages() {
+			outputEBS, err := volumePaginator.NextPage(ctx)
+			if err != nil {
+				return nil, nil, err
+			}
+			stoppedInstanceVolumes = append(stoppedInstanceVolumes, outputEBS.Volumes...)
+		}
 	}
 
 	return stoppedInstanceForMoreThan30Days, stoppedInstanceVolumes, nil

--- a/service/elb/service.go
+++ b/service/elb/service.go
@@ -16,27 +16,38 @@ func NewService(awsconfig aws.Config) *service {
 }
 
 func (s *service) GetUnusedLoadBalancers(ctx context.Context) ([]types.LoadBalancer, error) {
-	lbOutput, err := s.client.DescribeLoadBalancers(ctx, &elb.DescribeLoadBalancersInput{})
-	if err != nil {
-		return nil, err
+	// Collect all load balancers using pagination
+	var allLoadBalancers []types.LoadBalancer
+	lbPaginator := elb.NewDescribeLoadBalancersPaginator(s.client, &elb.DescribeLoadBalancersInput{})
+
+	for lbPaginator.HasMorePages() {
+		lbOutput, err := lbPaginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		allLoadBalancers = append(allLoadBalancers, lbOutput.LoadBalancers...)
 	}
 
-	tgOutput, err := s.client.DescribeTargetGroups(ctx, &elb.DescribeTargetGroupsInput{})
-	if err != nil {
-		return nil, err
-	}
-
+	// Collect all target groups using pagination
 	usedLbArns := make(map[string]bool)
+	tgPaginator := elb.NewDescribeTargetGroupsPaginator(s.client, &elb.DescribeTargetGroupsInput{})
 
-	for _, tg := range tgOutput.TargetGroups {
-		for _, lbArn := range tg.LoadBalancerArns {
-			usedLbArns[lbArn] = true
+	for tgPaginator.HasMorePages() {
+		tgOutput, err := tgPaginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, tg := range tgOutput.TargetGroups {
+			for _, lbArn := range tg.LoadBalancerArns {
+				usedLbArns[lbArn] = true
+			}
 		}
 	}
 
+	// Find orphaned load balancers
 	var orphanedLbs []types.LoadBalancer
 
-	for _, lb := range lbOutput.LoadBalancers {
+	for _, lb := range allLoadBalancers {
 		if lb.Type != types.LoadBalancerTypeEnumApplication && lb.Type != types.LoadBalancerTypeEnumNetwork {
 			continue
 		}


### PR DESCRIPTION
## Summary

Adds pagination support using AWS SDK v2 paginators to ensure aws-doctor works correctly on AWS accounts with large numbers of resources.

## Problem

The current implementation makes single API calls that return only the first page of results. AWS APIs have pagination limits (typically 50-1000 items per page). On accounts with many resources, the tool would miss items beyond the first page.

## Solution

Use AWS SDK v2's built-in paginator helpers:

### EC2 Service (`service/ec2/service.go`)

| Method | Paginator Used |
|--------|---------------|
| `GetUnusedEBSVolumes` | `DescribeVolumesPaginator` |
| `GetStoppedInstancesInfo` | `DescribeInstancesPaginator` + `DescribeVolumesPaginator` |

### ELB Service (`service/elb/service.go`)

| Method | Paginator Used |
|--------|---------------|
| `GetUnusedLoadBalancers` | `DescribeLoadBalancersPaginator` + `DescribeTargetGroupsPaginator` |

## Code Changes

- `service/ec2/service.go`: Refactored to use paginators for volume and instance queries
- `service/elb/service.go`: Refactored to use paginators for LB and target group queries
- `service/elb/types.go`: Standardized import alias, renamed interface to `ELBService`

## Why Paginators?

The AWS SDK v2 paginator pattern:
```go
paginator := ec2.NewDescribeVolumesPaginator(client, input)
for paginator.HasMorePages() {
    output, err := paginator.NextPage(ctx)
    // process output.Volumes...
}
```

Benefits:
- Handles NextToken/Marker automatically
- Clean, idiomatic Go code
- No risk of infinite loops
- Consistent with AWS SDK best practices

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing on account with >50 EBS volumes
- [ ] Manual testing on account with >50 stopped instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)