### PR TITLE
feat: add JSON export functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Available platforms:
 - `--profile`: Specify the AWS profile to use (default is "").
 - `--region`: Specify the AWS region to use. If not provided, uses `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables, or the region from `~/.aws/config`.
 - `--trend`: Shows a trend analysis for the last 6 months.
+- `--output`: Output format: `table` (default) or `json`.
 - `--waste`: Makes an analysis of possible money waste you have in your AWS Account.
   - [x] Unused EBS Volumes (not attached to any instance).
   - [x] EBS Volumes attached to stopped EC2 instances.
@@ -74,5 +75,6 @@ Available platforms:
 
 - [x] Add monthly trend analysis
 - [x] Add waste / wastage analysis logic
+- [x] Export reports to JSON format
 - [ ] Export reports to CSV and PDF formats (medical records for your cloud)
 - [ ] Distribute the CLI via Fedora, Ubuntu, and macOS repositories

--- a/model/flag.go
+++ b/model/flag.go
@@ -5,4 +5,5 @@ type Flags struct {
 	Profile string
 	Trend   bool
 	Waste   bool
+	Output  string // Output format: "table" (default) or "json"
 }

--- a/model/output.go
+++ b/model/output.go
@@ -1,0 +1,92 @@
+package model
+
+// CostComparisonJSON represents the JSON output for cost comparison
+type CostComparisonJSON struct {
+	AccountID        string                   `json:"account_id"`
+	GeneratedAt      string                   `json:"generated_at"`
+	CurrentMonth     CostPeriodJSON           `json:"current_month"`
+	LastMonth        CostPeriodJSON           `json:"last_month"`
+	ServiceBreakdown []ServiceCostCompareJSON `json:"service_breakdown"`
+}
+
+// CostPeriodJSON represents cost data for a time period
+type CostPeriodJSON struct {
+	Start string  `json:"start"`
+	End   string  `json:"end"`
+	Total float64 `json:"total"`
+	Unit  string  `json:"unit"`
+}
+
+// ServiceCostCompareJSON represents cost comparison for a single service
+type ServiceCostCompareJSON struct {
+	Service     string  `json:"service"`
+	CurrentCost float64 `json:"current_cost"`
+	LastCost    float64 `json:"last_cost"`
+	Difference  float64 `json:"difference"`
+	Unit        string  `json:"unit"`
+}
+
+// TrendJSON represents the JSON output for trend analysis
+type TrendJSON struct {
+	AccountID   string          `json:"account_id"`
+	GeneratedAt string          `json:"generated_at"`
+	Months      []MonthCostJSON `json:"months"`
+}
+
+// MonthCostJSON represents cost data for a single month
+type MonthCostJSON struct {
+	Start string  `json:"start"`
+	End   string  `json:"end"`
+	Total float64 `json:"total"`
+	Unit  string  `json:"unit"`
+}
+
+// WasteReportJSON represents the JSON output for waste detection
+type WasteReportJSON struct {
+	AccountID           string                 `json:"account_id"`
+	GeneratedAt         string                 `json:"generated_at"`
+	HasWaste            bool                   `json:"has_waste"`
+	UnusedElasticIPs    []ElasticIPJSON        `json:"unused_elastic_ips"`
+	UnusedEBSVolumes    []EBSVolumeJSON        `json:"unused_ebs_volumes"`
+	StoppedVolumes      []EBSVolumeJSON        `json:"stopped_instance_volumes"`
+	StoppedInstances    []StoppedInstanceJSON  `json:"stopped_instances"`
+	ReservedInstances   []ReservedInstanceJSON `json:"reserved_instances"`
+	UnusedLoadBalancers []LoadBalancerJSON     `json:"unused_load_balancers"`
+}
+
+// ElasticIPJSON represents an unused Elastic IP
+type ElasticIPJSON struct {
+	PublicIP     string `json:"public_ip"`
+	AllocationID string `json:"allocation_id"`
+}
+
+// EBSVolumeJSON represents an EBS volume
+type EBSVolumeJSON struct {
+	VolumeID string `json:"volume_id"`
+	Size     int32  `json:"size_gib"`
+	Status   string `json:"status"`
+}
+
+// StoppedInstanceJSON represents a stopped EC2 instance
+type StoppedInstanceJSON struct {
+	InstanceID string `json:"instance_id"`
+	StoppedAt  string `json:"stopped_at,omitempty"`
+	DaysAgo    int    `json:"days_ago,omitempty"`
+}
+
+// ReservedInstanceJSON represents a reserved instance
+type ReservedInstanceJSON struct {
+	ReservedInstanceID string `json:"reserved_instance_id"`
+	InstanceType       string `json:"instance_type"`
+	ExpirationDate     string `json:"expiration_date"`
+	DaysUntilExpiry    int    `json:"days_until_expiry"`
+	State              string `json:"state"`
+	Status             string `json:"status"`
+}
+
+// LoadBalancerJSON represents an unused load balancer
+type LoadBalancerJSON struct {
+	Name string `json:"name"`
+	ARN  string `json:"arn"`
+	Type string `json:"type"`
+}

--- a/service/flag/service.go
+++ b/service/flag/service.go
@@ -15,6 +15,7 @@ func (s *service) GetParsedFlags() (model.Flags, error) {
 	profile := flag.String("profile", "", "AWS profile configuration")
 	trend := flag.Bool("trend", false, "Display a trend report for the last 6 months")
 	waste := flag.Bool("waste", false, "Display AWS waste report")
+	output := flag.String("output", "table", "Output format: table or json")
 
 	flag.Parse()
 
@@ -23,5 +24,6 @@ func (s *service) GetParsedFlags() (model.Flags, error) {
 		Profile: *profile,
 		Trend:   *trend,
 		Waste:   *waste,
+		Output:  *output,
 	}, nil
 }

--- a/utils/cost.go
+++ b/utils/cost.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"strconv"
+	"strings"
+)
+
+// ParseCostString parses a cost string like "123.45 USD" into a float64
+func ParseCostString(costStr string) float64 {
+	parts := strings.Split(costStr, " ")
+	if len(parts) == 0 {
+		return 0
+	}
+	amount, _ := strconv.ParseFloat(parts[0], 64)
+	return amount
+}

--- a/utils/json_output.go
+++ b/utils/json_output.go
@@ -1,0 +1,163 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/elC0mpa/aws-doctor/model"
+)
+
+// OutputCostComparisonJSON outputs cost comparison data as JSON
+func OutputCostComparisonJSON(accountID string, lastTotalCost, currentTotalCost float64, lastMonth, currentMonth *model.CostInfo) error {
+	output := model.CostComparisonJSON{
+		AccountID:   accountID,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		CurrentMonth: model.CostPeriodJSON{
+			Start: aws.ToString(currentMonth.Start),
+			End:   aws.ToString(currentMonth.End),
+			Total: currentTotalCost,
+			Unit:  "USD",
+		},
+		LastMonth: model.CostPeriodJSON{
+			Start: aws.ToString(lastMonth.Start),
+			End:   aws.ToString(lastMonth.End),
+			Total: lastTotalCost,
+			Unit:  "USD",
+		},
+		ServiceBreakdown: []model.ServiceCostCompareJSON{},
+	}
+
+	// Add service breakdown
+	for serviceName, currentCost := range currentMonth.CostGroup {
+		lastCost := lastMonth.CostGroup[serviceName]
+		output.ServiceBreakdown = append(output.ServiceBreakdown, model.ServiceCostCompareJSON{
+			Service:     serviceName,
+			CurrentCost: currentCost.Amount,
+			LastCost:    lastCost.Amount,
+			Difference:  currentCost.Amount - lastCost.Amount,
+			Unit:        currentCost.Unit,
+		})
+	}
+
+	return printJSON(output)
+}
+
+// OutputTrendJSON outputs trend data as JSON
+func OutputTrendJSON(accountID string, costInfo []model.CostInfo) error {
+	output := model.TrendJSON{
+		AccountID:   accountID,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Months:      []model.MonthCostJSON{},
+	}
+
+	for _, info := range costInfo {
+		if total, ok := info.CostGroup["Total"]; ok {
+			output.Months = append(output.Months, model.MonthCostJSON{
+				Start: aws.ToString(info.Start),
+				End:   aws.ToString(info.End),
+				Total: total.Amount,
+				Unit:  total.Unit,
+			})
+		}
+	}
+
+	return printJSON(output)
+}
+
+// OutputWasteJSON outputs waste detection data as JSON
+func OutputWasteJSON(accountID string, elasticIPs []types.Address, unusedVolumes []types.Volume, stoppedVolumes []types.Volume, ris []model.RiExpirationInfo, stoppedInstances []types.Instance, loadBalancers []elbtypes.LoadBalancer) error {
+	output := model.WasteReportJSON{
+		AccountID:           accountID,
+		GeneratedAt:         time.Now().UTC().Format(time.RFC3339),
+		UnusedElasticIPs:    []model.ElasticIPJSON{},
+		UnusedEBSVolumes:    []model.EBSVolumeJSON{},
+		StoppedVolumes:      []model.EBSVolumeJSON{},
+		StoppedInstances:    []model.StoppedInstanceJSON{},
+		ReservedInstances:   []model.ReservedInstanceJSON{},
+		UnusedLoadBalancers: []model.LoadBalancerJSON{},
+	}
+
+	// Unused Elastic IPs
+	for _, ip := range elasticIPs {
+		output.UnusedElasticIPs = append(output.UnusedElasticIPs, model.ElasticIPJSON{
+			PublicIP:     aws.ToString(ip.PublicIp),
+			AllocationID: aws.ToString(ip.AllocationId),
+		})
+	}
+
+	// Unused EBS Volumes
+	for _, vol := range unusedVolumes {
+		output.UnusedEBSVolumes = append(output.UnusedEBSVolumes, model.EBSVolumeJSON{
+			VolumeID: aws.ToString(vol.VolumeId),
+			Size:     aws.ToInt32(vol.Size),
+			Status:   "available",
+		})
+	}
+
+	// EBS Volumes attached to stopped instances
+	for _, vol := range stoppedVolumes {
+		output.StoppedVolumes = append(output.StoppedVolumes, model.EBSVolumeJSON{
+			VolumeID: aws.ToString(vol.VolumeId),
+			Size:     aws.ToInt32(vol.Size),
+			Status:   "attached_to_stopped",
+		})
+	}
+
+	// Stopped instances
+	now := time.Now()
+	for _, instance := range stoppedInstances {
+		si := model.StoppedInstanceJSON{
+			InstanceID: aws.ToString(instance.InstanceId),
+		}
+		if instance.StateTransitionReason != nil {
+			if stoppedAt, err := ParseTransitionDate(*instance.StateTransitionReason); err == nil {
+				si.StoppedAt = stoppedAt.Format(time.RFC3339)
+				si.DaysAgo = int(now.Sub(stoppedAt).Hours() / 24)
+			}
+		}
+		output.StoppedInstances = append(output.StoppedInstances, si)
+	}
+
+	// Reserved instances
+	for _, ri := range ris {
+		output.ReservedInstances = append(output.ReservedInstances, model.ReservedInstanceJSON{
+			ReservedInstanceID: ri.ReservedInstanceId,
+			InstanceType:       ri.InstanceType,
+			ExpirationDate:     ri.ExpirationDate.Format(time.RFC3339),
+			DaysUntilExpiry:    ri.DaysUntilExpiry,
+			State:              ri.State,
+			Status:             ri.Status,
+		})
+	}
+
+	// Unused load balancers
+	for _, lb := range loadBalancers {
+		output.UnusedLoadBalancers = append(output.UnusedLoadBalancers, model.LoadBalancerJSON{
+			Name: aws.ToString(lb.LoadBalancerName),
+			ARN:  aws.ToString(lb.LoadBalancerArn),
+			Type: string(lb.Type),
+		})
+	}
+
+	output.HasWaste = len(output.UnusedElasticIPs) > 0 ||
+		len(output.UnusedEBSVolumes) > 0 ||
+		len(output.StoppedVolumes) > 0 ||
+		len(output.StoppedInstances) > 0 ||
+		len(output.ReservedInstances) > 0 ||
+		len(output.UnusedLoadBalancers) > 0
+
+	return printJSON(output)
+}
+
+func printJSON(v interface{}) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds JSON export functionality with a new `--output` flag, enabling machine-readable output for all report types.

## New Flag

```
--output    Output format: table (default) or json
```

## Usage Examples

```bash
# Cost comparison in JSON
aws-doctor --output json

# Trend analysis in JSON  
aws-doctor --trend --output json

# Waste detection in JSON
aws-doctor --waste --output json

# Pipe to jq for processing
aws-doctor --waste --output json | jq '.unused_elastic_ips'
```

## JSON Output Schemas

### Cost Comparison (`aws-doctor --output json`)
```json
{
  "account_id": "123456789012",
  "generated_at": "2024-01-15T10:30:00Z",
  "current_month": { "start": "2024-01-01", "end": "2024-01-15", "total": 1234.56, "unit": "USD" },
  "last_month": { "start": "2023-12-01", "end": "2023-12-15", "total": 1100.00, "unit": "USD" },
  "service_breakdown": [...]
}
```

### Trend Analysis (`aws-doctor --trend --output json`)
```json
{
  "account_id": "123456789012",
  "generated_at": "2024-01-15T10:30:00Z",
  "months": [
    { "start": "2023-07-01", "end": "2023-08-01", "total": 1000.00, "unit": "USD" },
    ...
  ]
}
```

### Waste Detection (`aws-doctor --waste --output json`)
```json
{
  "account_id": "123456789012",
  "generated_at": "2024-01-15T10:30:00Z",
  "has_waste": true,
  "unused_elastic_ips": [...],
  "unused_ebs_volumes": [...],
  "stopped_instance_volumes": [...],
  "stopped_instances": [...],
  "reserved_instances": [...]
}
```

## Changes

| File | Description |
|------|-------------|
| `model/flag.go` | Add `Output` field to Flags struct |
| `service/flag/service.go` | Add `--output` flag parsing |
| `service/orchestrator/service.go` | Route to JSON output when `--output=json` |
| `utils/json_output.go` | New file with JSON formatting functions |
| `README.md` | Document new flag and update roadmap |

## Benefits

- **CI/CD Integration**: Parse output programmatically in pipelines
- **Automation**: Build alerting/monitoring on top of aws-doctor
- **Data Analysis**: Import into spreadsheets, databases, or dashboards
- **Scripting**: Process with jq, Python, or other tools

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing of `--output json` for all modes
- [ ] Verify JSON is valid and parseable with `jq`

🤖 Generated with [Claude Code](https://claude.com/claude-code)