### PR TITLE
Auto-detect AWS region from environment and config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Available platforms:
 ## Flags
 
 - `--profile`: Specify the AWS profile to use (default is "").
-- `--region`: Specify the AWS region to use (default is "us-east-1").
+- `--region`: Specify the AWS region to use. If not provided, uses `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables, or the region from `~/.aws/config`.
 - `--trend`: Shows a trend analysis for the last 6 months.
 - `--waste`: Makes an analysis of possible money waste you have in your AWS Account.
   - [x] Unused EBS Volumes (not attached to any instance).

--- a/service/aws_config/service.go
+++ b/service/aws_config/service.go
@@ -12,5 +12,18 @@ func NewService() *service {
 }
 
 func (s *service) GetAWSCfg(ctx context.Context, region, profile string) (aws.Config, error) {
-	return config.LoadDefaultConfig(ctx, config.WithRegion(region), config.WithSharedConfigProfile(profile))
+	var opts []func(*config.LoadOptions) error
+
+	// Only set region if explicitly provided; otherwise use SDK defaults
+	// (AWS_REGION, AWS_DEFAULT_REGION env vars, or ~/.aws/config)
+	if region != "" {
+		opts = append(opts, config.WithRegion(region))
+	}
+
+	// Only set profile if explicitly provided
+	if profile != "" {
+		opts = append(opts, config.WithSharedConfigProfile(profile))
+	}
+
+	return config.LoadDefaultConfig(ctx, opts...)
 }

--- a/service/flag/service.go
+++ b/service/flag/service.go
@@ -11,7 +11,7 @@ func NewService() *service {
 }
 
 func (s *service) GetParsedFlags() (model.Flags, error) {
-	region := flag.String("region", "us-east-1", "AWS region")
+	region := flag.String("region", "", "AWS region (defaults to AWS_REGION, AWS_DEFAULT_REGION, or ~/.aws/config)")
 	profile := flag.String("profile", "", "AWS profile configuration")
 	trend := flag.Bool("trend", false, "Display a trend report for the last 6 months")
 	waste := flag.Bool("waste", false, "Display AWS waste report")


### PR DESCRIPTION
## Summary

Instead of hardcoding `us-east-1` as the default region, aws-doctor now respects the AWS SDK's standard region resolution order, reading from `~/.aws/config` and environment variables.

## Problem

Previously, aws-doctor always defaulted to `us-east-1` when no `--region` flag was provided. This was inconvenient for users who:
- Work primarily in other regions (eu-west-1, ap-southeast-1, etc.)
- Have already configured their default region in `~/.aws/config`
- Use `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables

## Solution

Now follows the AWS SDK v2 default resolution order:

| Priority | Source | Example |
|----------|--------|---------|
| 1 | `--region` flag | `--region eu-west-1` |
| 2 | `AWS_REGION` env var | `export AWS_REGION=eu-west-1` |
| 3 | `AWS_DEFAULT_REGION` env var | `export AWS_DEFAULT_REGION=eu-west-1` |
| 4 | `~/.aws/config` file | `region = eu-west-1` under `[default]` or profile |
| 5 | Fallback | SDK default (us-east-1) |

## Changes

| File | Change |
|------|--------|
| `service/flag/service.go` | Change `--region` default from `"us-east-1"` to `""` |
| `service/aws_config/service.go` | Only apply `WithRegion()` when explicitly provided |
| `README.md` | Update flag documentation |

## Example ~/.aws/config

```ini
[default]
region = eu-west-1

[profile prod]
region = us-west-2
```

Now `aws-doctor` uses `eu-west-1`, and `aws-doctor --profile prod` uses `us-west-2`.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Test with `AWS_REGION` set
- [ ] Test with `~/.aws/config` region configured
- [ ] Test with explicit `--region` flag (should override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)