### PR TITLE
feat: integrate ELB service for unused load balancer detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Available platforms:
   - [x] EC2 reserved instance that are scheduled to expire in the next 30 days or have expired in the preceding 30 days.
   - [x] EC2 instance stopped for more than 30 days.
   - [x] EC2 instances stopped for more than 30 days.
-  - [ ] Load Balancers with no attached target groups.
+  - [x] Load Balancers with no attached target groups.
   - [ ] Inactive VPC interface endpoints.
   - [ ] Inactive NAT Gateways.
   - [ ] Idle Load Balancers.

--- a/app.go
+++ b/app.go
@@ -8,6 +8,7 @@ import (
 	awsconfig "github.com/elC0mpa/aws-doctor/service/aws_config"
 	awscostexplorer "github.com/elC0mpa/aws-doctor/service/costexplorer"
 	awsec2 "github.com/elC0mpa/aws-doctor/service/ec2"
+	awselb "github.com/elC0mpa/aws-doctor/service/elb"
 	"github.com/elC0mpa/aws-doctor/service/flag"
 	"github.com/elC0mpa/aws-doctor/service/orchestrator"
 	awssts "github.com/elC0mpa/aws-doctor/service/sts"
@@ -41,8 +42,9 @@ func run() error {
 	costService := awscostexplorer.NewService(awsCfg)
 	stsService := awssts.NewService(awsCfg)
 	ec2Service := awsec2.NewService(awsCfg)
+	elbService := awselb.NewService(awsCfg)
 
-	orchestratorService := orchestrator.NewService(stsService, costService, ec2Service)
+	orchestratorService := orchestrator.NewService(stsService, costService, ec2Service, elbService)
 
 	if err := orchestratorService.Orchestrate(flags); err != nil {
 		return fmt.Errorf("orchestration failed: %w", err)

--- a/service/elb/types.go
+++ b/service/elb/types.go
@@ -11,6 +11,6 @@ type service struct {
 	client *elb.Client
 }
 
-type EC2Service interface {
+type ELBService interface {
 	GetUnusedLoadBalancers(ctx context.Context) ([]types.LoadBalancer, error)
 }

--- a/service/orchestrator/types.go
+++ b/service/orchestrator/types.go
@@ -4,6 +4,7 @@ import (
 	"github.com/elC0mpa/aws-doctor/model"
 	awscostexplorer "github.com/elC0mpa/aws-doctor/service/costexplorer"
 	awsec2 "github.com/elC0mpa/aws-doctor/service/ec2"
+	awselb "github.com/elC0mpa/aws-doctor/service/elb"
 	awssts "github.com/elC0mpa/aws-doctor/service/sts"
 )
 
@@ -11,6 +12,7 @@ type service struct {
 	stsService  awssts.STSService
 	costService awscostexplorer.CostService
 	ec2Service  awsec2.EC2Service
+	elbService  awselb.ELBService
 }
 
 type OrchestratorService interface {


### PR DESCRIPTION
## Summary
- Integrate the existing ELB service into the waste analysis workflow
- Fix the ELB interface name from `EC2Service` to `ELBService`
- Add a "Load Balancer Waste" display table showing load balancers with no attached target groups
- Update README to mark the "Load Balancers with no attached target groups" feature as complete

## Details
The ELB service already had a `GetUnusedLoadBalancers` method that detects Application and Network Load Balancers with no target groups attached. This PR wires it up to the waste workflow so these orphaned load balancers are displayed to users.

### Changes
- **service/elb/types.go**: Renamed interface from `EC2Service` to `ELBService`
- **service/orchestrator/types.go**: Added `elbService` field to service struct
- **service/orchestrator/service.go**: Updated `NewService` to accept ELB service, added call to `GetUnusedLoadBalancers` in waste workflow
- **utils/waste_table.go**: Added `drawLoadBalancerTable` function with red "No Target Groups" status
- **app.go**: Create and inject ELB service instance

## Test plan
- [x] Build passes: `go build -o aws-doctor .`
- [ ] Run `aws-doctor --waste` to verify load balancers without target groups are displayed
- [ ] Verify the table renders correctly with LB name and type

🤖 Generated with [Claude Code](https://claude.com/claude-code)