### PR TITLE
fix: wrap orchestration error with context

### DIFF
--- a/app.go
+++ b/app.go
@@ -45,7 +45,7 @@ func run() error {
 	orchestratorService := orchestrator.NewService(stsService, costService, ec2Service)
 
 	if err := orchestratorService.Orchestrate(flags); err != nil {
-		return err
+		return fmt.Errorf("orchestration failed: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Wraps the error from `orchestratorService.Orchestrate` with context using `fmt.Errorf("orchestration failed: %w", err)`
- Addresses review feedback from PR #7: https://github.com/elC0mpa/aws-doctor/pull/7#discussion_r2710979939

## Changes
This ensures consistent error context throughout the `run()` function, matching the pattern used for other errors (e.g., "failed to parse flags", "failed to load AWS config").

🤖 Generated with [Claude Code](https://claude.ai/code)