### PR TITLE
feat: add orphaned EBS snapshots detection

### DIFF
--- a/model/ec2.go
+++ b/model/ec2.go
@@ -35,3 +35,17 @@ type AMIWasteInfo struct {
 	UsedByInstances int       // Number of instances using this AMI
 	EstimatedCost   float64   // Monthly storage cost of associated snapshots
 }
+
+// SnapshotWasteInfo contains information about potentially orphaned EBS snapshots
+type SnapshotWasteInfo struct {
+	SnapshotId      string
+	VolumeId        string    // Source volume ID (may no longer exist)
+	VolumeExists    bool      // Whether the source volume still exists
+	UsedByAMI       bool      // Whether snapshot is used by an AMI
+	AMIId           string    // AMI ID if used
+	SizeGB          int32     // Snapshot size in GB
+	StartTime       time.Time // When snapshot was created
+	DaysSinceCreate int       // Days since creation
+	Description     string
+	EstimatedCost   float64   // Monthly storage cost estimate
+}

--- a/model/output.go
+++ b/model/output.go
@@ -53,6 +53,7 @@ type WasteReportJSON struct {
 	ReservedInstances   []ReservedInstanceJSON `json:"reserved_instances"`
 	UnusedLoadBalancers []LoadBalancerJSON     `json:"unused_load_balancers"`
 	UnusedAMIs          []AMIJSON              `json:"unused_amis"`
+	OrphanedSnapshots   []SnapshotJSON         `json:"orphaned_snapshots"`
 }
 
 // ElasticIPJSON represents an unused Elastic IP
@@ -103,4 +104,18 @@ type AMIJSON struct {
 	SnapshotIDs     []string `json:"snapshot_ids"`
 	SnapshotSizeGB  int64    `json:"snapshot_size_gb"`
 	EstimatedCost   float64  `json:"estimated_monthly_cost"`
+}
+
+// SnapshotJSON represents an orphaned EBS snapshot
+type SnapshotJSON struct {
+	SnapshotID      string  `json:"snapshot_id"`
+	VolumeID        string  `json:"volume_id,omitempty"`
+	VolumeExists    bool    `json:"volume_exists"`
+	UsedByAMI       bool    `json:"used_by_ami"`
+	AMIID           string  `json:"ami_id,omitempty"`
+	SizeGB          int32   `json:"size_gb"`
+	StartTime       string  `json:"start_time"`
+	DaysSinceCreate int     `json:"days_since_create"`
+	Description     string  `json:"description,omitempty"`
+	EstimatedCost   float64 `json:"estimated_monthly_cost"`
 }

--- a/service/ec2/types.go
+++ b/service/ec2/types.go
@@ -19,4 +19,5 @@ type EC2Service interface {
 	GetStoppedInstancesInfo(ctx context.Context) ([]types.Instance, []types.Volume, error)
 	GetReservedInstanceExpiringOrExpired30DaysWaste(ctx context.Context) ([]model.RiExpirationInfo, error)
 	GetUnusedAMIs(ctx context.Context, staleDays int) ([]model.AMIWasteInfo, error)
+	GetOrphanedSnapshots(ctx context.Context, staleDays int) ([]model.SnapshotWasteInfo, error)
 }

--- a/utils/json_output_test.go
+++ b/utils/json_output_test.go
@@ -246,7 +246,7 @@ func TestOutputWasteJSON(t *testing.T) {
 
 	var err error
 	output := captureStdout(func() {
-		err = OutputWasteJSON("123456789012", elasticIPs, unusedVolumes, stoppedVolumes, ris, stoppedInstances, loadBalancers, nil)
+		err = OutputWasteJSON("123456789012", elasticIPs, unusedVolumes, stoppedVolumes, ris, stoppedInstances, loadBalancers, nil, nil)
 	})
 
 	if err != nil {
@@ -295,7 +295,7 @@ func TestOutputWasteJSON(t *testing.T) {
 func TestOutputWasteJSON_NoWaste(t *testing.T) {
 	var err error
 	output := captureStdout(func() {
-		err = OutputWasteJSON("123456789012", nil, nil, nil, nil, nil, nil, nil)
+		err = OutputWasteJSON("123456789012", nil, nil, nil, nil, nil, nil, nil, nil)
 	})
 
 	if err != nil {
@@ -322,7 +322,7 @@ func TestOutputWasteJSON_InstanceWithoutTransitionReason(t *testing.T) {
 
 	var err error
 	output := captureStdout(func() {
-		err = OutputWasteJSON("123456789012", nil, nil, nil, nil, stoppedInstances, nil, nil)
+		err = OutputWasteJSON("123456789012", nil, nil, nil, nil, stoppedInstances, nil, nil, nil)
 	})
 
 	if err != nil {
@@ -354,7 +354,7 @@ func TestOutputWasteJSON_InstanceWithInvalidTransitionReason(t *testing.T) {
 
 	var err error
 	output := captureStdout(func() {
-		err = OutputWasteJSON("123456789012", nil, nil, nil, nil, stoppedInstances, nil, nil)
+		err = OutputWasteJSON("123456789012", nil, nil, nil, nil, stoppedInstances, nil, nil, nil)
 	})
 
 	if err != nil {
@@ -388,6 +388,6 @@ func BenchmarkOutputWasteJSON(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		OutputWasteJSON("123456789012", elasticIPs, nil, nil, nil, nil, nil, nil)
+		OutputWasteJSON("123456789012", elasticIPs, nil, nil, nil, nil, nil, nil, nil)
 	}
 }

--- a/utils/waste_table_test.go
+++ b/utils/waste_table_test.go
@@ -493,7 +493,7 @@ func captureWasteOutput(f func()) string {
 
 func TestDrawWasteTable_NoWaste(t *testing.T) {
 	output := captureWasteOutput(func() {
-		DrawWasteTable("123456789012", nil, nil, nil, nil, nil, nil, nil)
+		DrawWasteTable("123456789012", nil, nil, nil, nil, nil, nil, nil, nil)
 	})
 
 	if !strings.Contains(output, "AWS DOCTOR CHECKUP") {
@@ -515,7 +515,7 @@ func TestDrawWasteTable_WithElasticIPs(t *testing.T) {
 	}
 
 	output := captureWasteOutput(func() {
-		DrawWasteTable("123456789012", elasticIPs, nil, nil, nil, nil, nil, nil)
+		DrawWasteTable("123456789012", elasticIPs, nil, nil, nil, nil, nil, nil, nil)
 	})
 
 	if !strings.Contains(output, "Elastic IP") {
@@ -529,7 +529,7 @@ func TestDrawWasteTable_WithEBSVolumes(t *testing.T) {
 	}
 
 	output := captureWasteOutput(func() {
-		DrawWasteTable("123456789012", nil, unusedVolumes, nil, nil, nil, nil, nil)
+		DrawWasteTable("123456789012", nil, unusedVolumes, nil, nil, nil, nil, nil, nil)
 	})
 
 	if !strings.Contains(output, "EBS") {
@@ -546,7 +546,7 @@ func TestDrawWasteTable_WithStoppedInstances(t *testing.T) {
 	}
 
 	output := captureWasteOutput(func() {
-		DrawWasteTable("123456789012", nil, nil, nil, nil, stoppedInstances, nil, nil)
+		DrawWasteTable("123456789012", nil, nil, nil, nil, stoppedInstances, nil, nil, nil)
 	})
 
 	if !strings.Contains(output, "EC2") || !strings.Contains(output, "Reserved Instance") {
@@ -564,7 +564,7 @@ func TestDrawWasteTable_WithReservedInstances(t *testing.T) {
 	}
 
 	output := captureWasteOutput(func() {
-		DrawWasteTable("123456789012", nil, nil, nil, ris, nil, nil, nil)
+		DrawWasteTable("123456789012", nil, nil, nil, ris, nil, nil, nil, nil)
 	})
 
 	if !strings.Contains(output, "Reserved Instance") {
@@ -581,7 +581,7 @@ func TestDrawWasteTable_WithLoadBalancers(t *testing.T) {
 	}
 
 	output := captureWasteOutput(func() {
-		DrawWasteTable("123456789012", nil, nil, nil, nil, nil, loadBalancers, nil)
+		DrawWasteTable("123456789012", nil, nil, nil, nil, nil, loadBalancers, nil, nil)
 	})
 
 	if !strings.Contains(output, "Load Balancer") {
@@ -610,7 +610,7 @@ func TestDrawWasteTable_AllWasteTypes(t *testing.T) {
 	}
 
 	output := captureWasteOutput(func() {
-		DrawWasteTable("123456789012", elasticIPs, unusedVolumes, stoppedVolumes, ris, stoppedInstances, loadBalancers, nil)
+		DrawWasteTable("123456789012", elasticIPs, unusedVolumes, stoppedVolumes, ris, stoppedInstances, loadBalancers, nil, nil)
 	})
 
 	// Should have all sections
@@ -800,6 +800,6 @@ func BenchmarkDrawWasteTable(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		DrawWasteTable("123456789012", elasticIPs, unusedVolumes, nil, nil, nil, nil, nil)
+		DrawWasteTable("123456789012", elasticIPs, unusedVolumes, nil, nil, nil, nil, nil, nil)
 	}
 }


### PR DESCRIPTION
## Summary
- Add detection for potentially orphaned EBS snapshots in the waste workflow
- Identify snapshots where source volume no longer exists
- Identify snapshots older than a configurable threshold (default 90 days)
- Exclude snapshots used by AMIs from orphaned detection
- Display estimated monthly storage cost (~$0.05/GB/month)

## Implementation
- Add `GetOrphanedSnapshots` method to EC2 service with pagination
- Add `SnapshotWasteInfo` model type for snapshot metadata
- Add `drawSnapshotTable` to waste table UI
- Add `OrphanedSnapshots` to JSON output format
- Integrate into wasteWorkflow with concurrent fetching

## Test plan
- [ ] Test with AWS account containing orphaned snapshots
- [ ] Verify snapshots used by AMIs are excluded
- [ ] Verify JSON output includes snapshot data
- [ ] Verify cost estimation is displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)