### PR TITLE
feat: add daily cost analysis with day-of-week patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A terminal-based tool that acts as a comprehensive health check for your AWS acc
 - **📉 Cost Comparison:** Compares costs between the current and previous month for the exact same period (e.g., comparing Jan 1–15 vs Feb 1–15) to give a fair assessment of spending velocity.
 - **🏥 Waste Detection (The "Checkup"):** Scans your account for "zombie" resources and inefficiencies that are silently inflating your bill.
 - **📊 Trend Analysis:** Visualizes cost history over the last 6 months to spot long-term anomalies.
+- **📅 Daily Analysis:** Shows daily cost analysis for the last 30 days with day-of-week patterns.
 
 ## Motivation
 
@@ -64,6 +65,7 @@ Available platforms:
 - `--profile`: Specify the AWS profile to use (default is "").
 - `--region`: Specify the AWS region to use. If not provided, uses `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables, or the region from `~/.aws/config`.
 - `--trend`: Shows a trend analysis for the last 6 months.
+- `--daily`: Shows daily cost analysis for the last 30 days with day-of-week patterns.
 - `--output`: Output format: `table` (default) or `json`.
 - `--waste`: Makes an analysis of possible money waste you have in your AWS Account.
   - [x] Unused EBS Volumes (not attached to any instance).
@@ -85,5 +87,6 @@ Available platforms:
 - [x] Add monthly trend analysis
 - [x] Add waste / wastage analysis logic
 - [x] Export reports to JSON format
+- [x] Add daily cost analysis
 - [ ] Export reports to CSV and PDF formats (medical records for your cloud)
 - [ ] Distribute the CLI via Fedora, Ubuntu, and macOS repositories

--- a/mocks/output_service.go
+++ b/mocks/output_service.go
@@ -27,6 +27,11 @@ func (m *MockOutputService) RenderWaste(accountID string, elasticIPs []types.Add
 	return args.Error(0)
 }
 
+func (m *MockOutputService) RenderDaily(accountID string, dailyCosts []model.DailyCost) error {
+	args := m.Called(accountID, dailyCosts)
+	return args.Error(0)
+}
+
 func (m *MockOutputService) StopSpinner() {
 	m.Called()
 }

--- a/model/cost.go
+++ b/model/cost.go
@@ -17,3 +17,11 @@ type ServiceCost struct {
 	Amount float64
 	Unit   string
 }
+
+// DailyCostInfo represents cost data for a single day
+type DailyCostInfo struct {
+	Date      string  // YYYY-MM-DD format
+	DayOfWeek string  // Monday, Tuesday, etc.
+	Amount    float64
+	Unit      string
+}

--- a/model/flag.go
+++ b/model/flag.go
@@ -5,5 +5,6 @@ type Flags struct {
 	Profile string
 	Trend   bool
 	Waste   bool
+	Daily   bool   // Show daily cost analysis for last 30 days
 	Output  string // Output format: "table" (default) or "json"
 }

--- a/service/costexplorer/types.go
+++ b/service/costexplorer/types.go
@@ -19,4 +19,5 @@ type CostService interface {
 	GetCurrentMonthTotalCosts(ctx context.Context) (*string, error)
 	GetLastMonthTotalCosts(ctx context.Context) (*string, error)
 	GetLastSixMonthsCosts(ctx context.Context) ([]model.CostInfo, error)
+	GetDailyCosts(ctx context.Context, days int) ([]model.DailyCostInfo, error)
 }

--- a/service/flag/service.go
+++ b/service/flag/service.go
@@ -15,6 +15,7 @@ func (s *service) GetParsedFlags() (model.Flags, error) {
 	profile := flag.String("profile", "", "AWS profile configuration")
 	trend := flag.Bool("trend", false, "Display a trend report for the last 6 months")
 	waste := flag.Bool("waste", false, "Display AWS waste report")
+	daily := flag.Bool("daily", false, "Display daily cost analysis for the last 30 days with day-of-week patterns")
 	output := flag.String("output", "table", "Output format: table or json")
 	flag.Bool("version", false, "Display version information")
 
@@ -25,6 +26,7 @@ func (s *service) GetParsedFlags() (model.Flags, error) {
 		Profile: *profile,
 		Trend:   *trend,
 		Waste:   *waste,
+		Daily:   *daily,
 		Output:  *output,
 	}, nil
 }

--- a/service/orchestrator/service.go
+++ b/service/orchestrator/service.go
@@ -34,6 +34,10 @@ func (s *service) Orchestrate(flags model.Flags) error {
 		return s.trendWorkflow()
 	}
 
+	if flags.Daily {
+		return s.dailyWorkflow()
+	}
+
 	return s.defaultWorkflow()
 }
 
@@ -82,6 +86,22 @@ func (s *service) trendWorkflow() error {
 	s.outputService.StopSpinner()
 
 	return s.outputService.RenderTrend(*stsResult.Account, costInfo)
+}
+
+func (s *service) dailyWorkflow() error {
+	dailyCosts, err := s.costService.GetDailyCosts(context.Background(), 30)
+	if err != nil {
+		return err
+	}
+
+	stsResult, err := s.stsService.GetCallerIdentity(context.Background())
+	if err != nil {
+		return err
+	}
+
+	s.outputService.StopSpinner()
+
+	return s.outputService.RenderDaily(*stsResult.Account, dailyCosts)
 }
 
 func (s *service) wasteWorkflow() error {

--- a/service/output/service.go
+++ b/service/output/service.go
@@ -49,6 +49,15 @@ func (s *service) RenderWaste(accountID string, elasticIPs []types.Address, unus
 	return nil
 }
 
+func (s *service) RenderDaily(accountID string, dailyCosts []model.DailyCost) error {
+	if s.format == FormatJSON {
+		return utils.OutputDailyJSON(accountID, dailyCosts)
+	}
+
+	utils.DrawDailyChart(accountID, dailyCosts)
+	return nil
+}
+
 func (s *service) StopSpinner() {
 	utils.StopSpinner()
 }

--- a/service/output/types.go
+++ b/service/output/types.go
@@ -30,6 +30,9 @@ type Service interface {
 	// RenderWaste outputs waste report data in the configured format
 	RenderWaste(accountID string, elasticIPs []types.Address, unusedVolumes []types.Volume, stoppedVolumes []types.Volume, ris []model.RiExpirationInfo, stoppedInstances []types.Instance, loadBalancers []elbtypes.LoadBalancer, unusedAMIs []model.AMIWasteInfo, orphanedSnapshots []model.SnapshotWasteInfo) error
 
+	// RenderDaily outputs daily cost data in the configured format
+	RenderDaily(accountID string, dailyCosts []model.DailyCost) error
+
 	// StopSpinner stops the loading spinner before rendering output
 	StopSpinner()
 }

--- a/utils/daily_chart.go
+++ b/utils/daily_chart.go
@@ -1,0 +1,344 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/elC0mpa/aws-doctor/model"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+)
+
+// DailyJSON represents the JSON output for daily cost analysis
+type DailyJSON struct {
+	AccountID       string              `json:"account_id"`
+	GeneratedAt     string              `json:"generated_at"`
+	Days            []DayCostJSON       `json:"days"`
+	DayOfWeekStats  []DayOfWeekStatJSON `json:"day_of_week_stats"`
+	TotalCost       float64             `json:"total_cost"`
+	AverageDailyCost float64            `json:"average_daily_cost"`
+}
+
+// DayCostJSON represents cost data for a single day
+type DayCostJSON struct {
+	Date      string  `json:"date"`
+	DayOfWeek string  `json:"day_of_week"`
+	Amount    float64 `json:"amount"`
+	Unit      string  `json:"unit"`
+}
+
+// DayOfWeekStatJSON represents aggregated stats for a day of week
+type DayOfWeekStatJSON struct {
+	DayOfWeek    string  `json:"day_of_week"`
+	TotalCost    float64 `json:"total_cost"`
+	AverageCost  float64 `json:"average_cost"`
+	Count        int     `json:"count"`
+}
+
+// DrawDailyChart displays daily cost data with day-of-week analysis
+func DrawDailyChart(accountId string, dailyCosts []model.DailyCostInfo) {
+	fmt.Printf("\n%s\n", text.FgHiWhite.Sprint(" 📅 DAILY COST ANALYSIS"))
+	fmt.Printf(" Account ID: %s\n", text.FgBlue.Sprint(accountId))
+	fmt.Println(text.FgHiBlue.Sprint(" ------------------------------------------------"))
+
+	if len(dailyCosts) == 0 {
+		fmt.Println("\n" + text.FgHiYellow.Sprint(" No daily cost data available."))
+		return
+	}
+
+	// Draw daily costs table
+	drawDailyCostsTable(dailyCosts)
+
+	// Draw day-of-week analysis
+	drawDayOfWeekTable(dailyCosts)
+}
+
+func drawDailyCostsTable(dailyCosts []model.DailyCostInfo) {
+	t := table.NewWriter()
+	t.SetOutputMirror(os.Stdout)
+	t.SetStyle(table.StyleRounded)
+	t.SetTitle("Last 30 Days Cost")
+
+	t.AppendHeader(table.Row{"Date", "Day", "Cost", "Visual"})
+
+	t.SetColumnConfigs([]table.ColumnConfig{
+		{Number: 3, Align: text.AlignRight},
+		{Number: 4, Align: text.AlignLeft},
+	})
+
+	// Find max cost for visual scaling
+	var maxCost float64
+	var totalCost float64
+	for _, day := range dailyCosts {
+		if day.Amount > maxCost {
+			maxCost = day.Amount
+		}
+		totalCost += day.Amount
+	}
+
+	// Display last 14 days to keep it readable
+	start := 0
+	if len(dailyCosts) > 14 {
+		start = len(dailyCosts) - 14
+	}
+
+	for _, day := range dailyCosts[start:] {
+		// Create visual bar
+		barLen := int((day.Amount / maxCost) * 20)
+		if barLen < 1 && day.Amount > 0 {
+			barLen = 1
+		}
+		bar := ""
+		for i := 0; i < barLen; i++ {
+			bar += "█"
+		}
+
+		// Color based on day of week
+		dayColor := text.FgWhite
+		if day.DayOfWeek == "Saturday" || day.DayOfWeek == "Sunday" {
+			dayColor = text.FgHiCyan
+		}
+
+		t.AppendRow(table.Row{
+			day.Date,
+			dayColor.Sprint(day.DayOfWeek[:3]),
+			fmt.Sprintf("$%.2f", day.Amount),
+			text.FgHiGreen.Sprint(bar),
+		})
+	}
+
+	t.AppendSeparator()
+	avgCost := totalCost / float64(len(dailyCosts))
+	t.AppendRow(table.Row{
+		"",
+		text.FgHiWhite.Sprint("Total"),
+		text.FgHiWhite.Sprintf("$%.2f", totalCost),
+		"",
+	})
+	t.AppendRow(table.Row{
+		"",
+		text.FgHiWhite.Sprint("Avg/Day"),
+		text.FgHiWhite.Sprintf("$%.2f", avgCost),
+		"",
+	})
+
+	t.Render()
+	fmt.Println()
+}
+
+func drawDayOfWeekTable(dailyCosts []model.DailyCostInfo) {
+	// Aggregate by day of week
+	dowStats := make(map[string]struct {
+		total float64
+		count int
+	})
+
+	for _, day := range dailyCosts {
+		stat := dowStats[day.DayOfWeek]
+		stat.total += day.Amount
+		stat.count++
+		dowStats[day.DayOfWeek] = stat
+	}
+
+	// Order days properly
+	dayOrder := []string{"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(os.Stdout)
+	t.SetStyle(table.StyleRounded)
+	t.SetTitle("Day-of-Week Pattern")
+
+	t.AppendHeader(table.Row{"Day", "Avg Cost", "Visual", "Pattern"})
+
+	t.SetColumnConfigs([]table.ColumnConfig{
+		{Number: 2, Align: text.AlignRight},
+	})
+
+	// Find max average for scaling
+	var maxAvg float64
+	for _, stat := range dowStats {
+		avg := stat.total / float64(stat.count)
+		if avg > maxAvg {
+			maxAvg = avg
+		}
+	}
+
+	// Calculate overall average
+	var totalAll float64
+	var countAll int
+	for _, stat := range dowStats {
+		totalAll += stat.total
+		countAll += stat.count
+	}
+	overallAvg := totalAll / float64(countAll)
+
+	for _, day := range dayOrder {
+		stat, ok := dowStats[day]
+		if !ok {
+			continue
+		}
+
+		avg := stat.total / float64(stat.count)
+
+		// Create visual bar
+		barLen := int((avg / maxAvg) * 15)
+		if barLen < 1 && avg > 0 {
+			barLen = 1
+		}
+		bar := ""
+		for i := 0; i < barLen; i++ {
+			bar += "█"
+		}
+
+		// Determine pattern indicator
+		pattern := ""
+		diff := ((avg - overallAvg) / overallAvg) * 100
+		if diff > 20 {
+			pattern = text.FgHiRed.Sprintf("↑ +%.0f%%", diff)
+		} else if diff < -20 {
+			pattern = text.FgHiGreen.Sprintf("↓ %.0f%%", diff)
+		} else {
+			pattern = text.FgHiWhite.Sprint("≈ avg")
+		}
+
+		// Color weekends differently
+		dayColor := text.FgWhite
+		barColor := text.FgHiBlue
+		if day == "Saturday" || day == "Sunday" {
+			dayColor = text.FgHiCyan
+			barColor = text.FgHiCyan
+		}
+
+		t.AppendRow(table.Row{
+			dayColor.Sprint(day),
+			fmt.Sprintf("$%.2f", avg),
+			barColor.Sprint(bar),
+			pattern,
+		})
+	}
+
+	t.Render()
+	fmt.Println()
+
+	// Print insights
+	printDailyInsights(dowStats, overallAvg)
+}
+
+func printDailyInsights(dowStats map[string]struct {
+	total float64
+	count int
+}, overallAvg float64) {
+	fmt.Println(text.FgHiWhite.Sprint(" 💡 Insights:"))
+
+	// Find highest and lowest days
+	var highestDay, lowestDay string
+	var highestAvg, lowestAvg float64 = 0, 999999999
+
+	for day, stat := range dowStats {
+		avg := stat.total / float64(stat.count)
+		if avg > highestAvg {
+			highestAvg = avg
+			highestDay = day
+		}
+		if avg < lowestAvg {
+			lowestAvg = avg
+			lowestDay = day
+		}
+	}
+
+	fmt.Printf("    • Highest spend: %s ($%.2f avg)\n", highestDay, highestAvg)
+	fmt.Printf("    • Lowest spend: %s ($%.2f avg)\n", lowestDay, lowestAvg)
+
+	// Weekend vs weekday comparison
+	var weekdayTotal, weekendTotal float64
+	var weekdayCount, weekendCount int
+	for day, stat := range dowStats {
+		if day == "Saturday" || day == "Sunday" {
+			weekendTotal += stat.total
+			weekendCount += stat.count
+		} else {
+			weekdayTotal += stat.total
+			weekdayCount += stat.count
+		}
+	}
+
+	if weekdayCount > 0 && weekendCount > 0 {
+		weekdayAvg := weekdayTotal / float64(weekdayCount)
+		weekendAvg := weekendTotal / float64(weekendCount)
+		diff := ((weekendAvg - weekdayAvg) / weekdayAvg) * 100
+
+		if diff > 10 {
+			fmt.Printf("    • Weekend spending is %.0f%% higher than weekdays\n", diff)
+		} else if diff < -10 {
+			fmt.Printf("    • Weekend spending is %.0f%% lower than weekdays\n", -diff)
+		} else {
+			fmt.Println("    • Weekend and weekday spending are similar")
+		}
+	}
+
+	fmt.Println()
+}
+
+// OutputDailyJSON outputs daily cost data as JSON
+func OutputDailyJSON(accountID string, dailyCosts []model.DailyCostInfo) error {
+	output := DailyJSON{
+		AccountID:   accountID,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Days:        make([]DayCostJSON, 0, len(dailyCosts)),
+	}
+
+	// Aggregate by day of week
+	dowStats := make(map[string]struct {
+		total float64
+		count int
+	})
+
+	var totalCost float64
+	for _, day := range dailyCosts {
+		output.Days = append(output.Days, DayCostJSON{
+			Date:      day.Date,
+			DayOfWeek: day.DayOfWeek,
+			Amount:    day.Amount,
+			Unit:      day.Unit,
+		})
+
+		stat := dowStats[day.DayOfWeek]
+		stat.total += day.Amount
+		stat.count++
+		dowStats[day.DayOfWeek] = stat
+		totalCost += day.Amount
+	}
+
+	output.TotalCost = totalCost
+	if len(dailyCosts) > 0 {
+		output.AverageDailyCost = totalCost / float64(len(dailyCosts))
+	}
+
+	// Build day-of-week stats
+	dayOrder := []string{"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}
+	for _, day := range dayOrder {
+		if stat, ok := dowStats[day]; ok {
+			output.DayOfWeekStats = append(output.DayOfWeekStats, DayOfWeekStatJSON{
+				DayOfWeek:   day,
+				TotalCost:   stat.total,
+				AverageCost: stat.total / float64(stat.count),
+				Count:       stat.count,
+			})
+		}
+	}
+
+	// Sort days by date
+	sort.Slice(output.Days, func(i, j int) bool {
+		return output.Days[i].Date < output.Days[j].Date
+	})
+
+	data, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add daily cost analysis feature to track spending patterns over time
- Display daily costs for the last 30 days
- Show day-of-week cost patterns (weekday vs weekend)
- Calculate average daily cost
- Identify highest and lowest spending days
- Support JSON output format

## Implementation
- Add `GetDailyCosts` method to Cost Explorer service
- Add `DailyCostInfo` model type
- Add `--daily` flag to CLI
- Add `DrawDailyChart` and `OutputDailyJSON` utilities
- Update README with new feature documentation

## Test plan
- [ ] Test `--daily` flag displays daily cost chart
- [ ] Verify day-of-week patterns are calculated correctly
- [ ] Test `--daily --output json` outputs valid JSON
- [ ] Verify cost data matches AWS Cost Explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)