### PR TITLE
docs: add CI workflow status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # aws-doctor
 
+[![CI](https://github.com/elC0mpa/aws-doctor/actions/workflows/ci.yml/badge.svg)](https://github.com/elC0mpa/aws-doctor/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/elC0mpa/aws-doctor)](https://goreportcard.com/report/github.com/elC0mpa/aws-doctor)
 [![Go Reference](https://pkg.go.dev/badge/github.com/elC0mpa/aws-doctor.svg)](https://pkg.go.dev/github.com/elC0mpa/aws-doctor)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/elC0mpa/aws-doctor)](https://github.com/elC0mpa/aws-doctor/blob/main/go.mod)


### PR DESCRIPTION
## Summary
Add CI workflow status badge to README.md to display build status at a glance.

## Dependencies
**This PR depends on PR #8** (Add CI workflow) being merged first, as the badge references the CI workflow that PR #8 adds.

## Test plan
- [ ] Verify badge displays correctly after PR #8 is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)