### PR TITLE
fix: refactor GetOrphanedSnapshots logic, pagination, and cost estimation

### DIFF
--- a/model/ec2.go
+++ b/model/ec2.go
@@ -36,16 +36,28 @@ type AMIWasteInfo struct {
 	EstimatedCost   float64   // Monthly storage cost of associated snapshots
 }
 
+// SnapshotCategory indicates whether a snapshot is orphaned or stale
+type SnapshotCategory string
+
+const (
+	// SnapshotCategoryOrphaned - source volume deleted, safe to delete (high confidence)
+	SnapshotCategoryOrphaned SnapshotCategory = "orphaned"
+	// SnapshotCategoryStale - volume exists but snapshot is old, needs review (low confidence)
+	SnapshotCategoryStale SnapshotCategory = "stale"
+)
+
 // SnapshotWasteInfo contains information about potentially orphaned EBS snapshots
 type SnapshotWasteInfo struct {
-	SnapshotId      string
-	VolumeId        string    // Source volume ID (may no longer exist)
-	VolumeExists    bool      // Whether the source volume still exists
-	UsedByAMI       bool      // Whether snapshot is used by an AMI
-	AMIId           string    // AMI ID if used
-	SizeGB          int32     // Snapshot size in GB
-	StartTime       time.Time // When snapshot was created
-	DaysSinceCreate int       // Days since creation
-	Description     string
-	EstimatedCost   float64   // Monthly storage cost estimate
+	SnapshotId          string
+	VolumeId            string           // Source volume ID (may no longer exist)
+	VolumeExists        bool             // Whether the source volume still exists
+	UsedByAMI           bool             // Whether snapshot is used by an AMI
+	AMIId               string           // AMI ID if used
+	SizeGB              int32            // Snapshot size in GB
+	StartTime           time.Time        // When snapshot was created
+	DaysSinceCreate     int              // Days since creation
+	Description         string
+	Category            SnapshotCategory // "orphaned" or "stale"
+	Reason              string           // Human-readable reason (e.g., "Volume Deleted", "Old Backup")
+	MaxPotentialSavings float64          // Max monthly savings (actual may be lower due to incremental storage)
 }

--- a/model/output.go
+++ b/model/output.go
@@ -54,6 +54,7 @@ type WasteReportJSON struct {
 	UnusedLoadBalancers []LoadBalancerJSON     `json:"unused_load_balancers"`
 	UnusedAMIs          []AMIJSON              `json:"unused_amis"`
 	OrphanedSnapshots   []SnapshotJSON         `json:"orphaned_snapshots"`
+	StaleSnapshots      []SnapshotJSON         `json:"stale_snapshots"`
 }
 
 // ElasticIPJSON represents an unused Elastic IP
@@ -106,16 +107,18 @@ type AMIJSON struct {
 	EstimatedCost   float64  `json:"estimated_monthly_cost"`
 }
 
-// SnapshotJSON represents an orphaned EBS snapshot
+// SnapshotJSON represents an orphaned or stale EBS snapshot
 type SnapshotJSON struct {
-	SnapshotID      string  `json:"snapshot_id"`
-	VolumeID        string  `json:"volume_id,omitempty"`
-	VolumeExists    bool    `json:"volume_exists"`
-	UsedByAMI       bool    `json:"used_by_ami"`
-	AMIID           string  `json:"ami_id,omitempty"`
-	SizeGB          int32   `json:"size_gb"`
-	StartTime       string  `json:"start_time"`
-	DaysSinceCreate int     `json:"days_since_create"`
-	Description     string  `json:"description,omitempty"`
-	EstimatedCost   float64 `json:"estimated_monthly_cost"`
+	SnapshotID          string  `json:"snapshot_id"`
+	VolumeID            string  `json:"volume_id,omitempty"`
+	VolumeExists        bool    `json:"volume_exists"`
+	UsedByAMI           bool    `json:"used_by_ami"`
+	AMIID               string  `json:"ami_id,omitempty"`
+	SizeGB              int32   `json:"size_gb"`
+	StartTime           string  `json:"start_time"`
+	DaysSinceCreate     int     `json:"days_since_create"`
+	Description         string  `json:"description,omitempty"`
+	Category            string  `json:"category"`                // "orphaned" or "stale"
+	Reason              string  `json:"reason"`                  // Human-readable reason
+	MaxPotentialSavings float64 `json:"max_potential_savings"`   // Actual savings may be lower due to incremental storage
 }


### PR DESCRIPTION
## Summary

Resolves #34 - Refactor GetOrphanedSnapshots: Fix Logic, Pagination, and Cost Estimation

- **Split Logic**: Differentiates between "orphaned" (volume deleted, safe to delete with high confidence) and "stale" (volume exists but snapshot is old, needs review with low confidence)
- **Pagination**: Implements pagination for `DescribeImages` using `NewDescribeImagesPaginator` to handle accounts with many AMIs
- **Cost Label**: Renames `EstimatedCost` to `MaxPotentialSavings` with a disclaimer noting actual savings may be lower due to incremental storage
- **UI Update**: Adds "Reason" column showing "Volume Deleted" vs "Old Backup" with color-coded priority (red for orphaned, yellow for stale)
- **JSON Output**: Splits snapshots into `orphaned_snapshots` and `stale_snapshots` arrays with category and reason fields

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (includes 8 new snapshot-specific tests)
- [ ] Manual testing with AWS account containing orphaned and stale snapshots
- [ ] Verify JSON output includes `orphaned_snapshots` and `stale_snapshots` arrays
- [ ] Verify table output shows correct categorization and reason column

🤖 Generated with [Claude Code](https://claude.com/claude-code)