### PR TITLE
refactor: create OutputService to encapsulate output logic

### DIFF
--- a/app.go
+++ b/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/elC0mpa/aws-doctor/service/elb"
 	"github.com/elC0mpa/aws-doctor/service/flag"
 	"github.com/elC0mpa/aws-doctor/service/orchestrator"
+	"github.com/elC0mpa/aws-doctor/service/output"
 	awssts "github.com/elC0mpa/aws-doctor/service/sts"
 	"github.com/elC0mpa/aws-doctor/utils"
 )
@@ -58,8 +59,9 @@ func run() error {
 	stsService := awssts.NewService(awsCfg)
 	ec2Service := awsec2.NewService(awsCfg)
 	elbService := elb.NewService(awsCfg)
+	outputService := output.NewService(flags.Output)
 
-	orchestratorService := orchestrator.NewService(stsService, costService, ec2Service, elbService)
+	orchestratorService := orchestrator.NewService(stsService, costService, ec2Service, elbService, outputService)
 
 	if err := orchestratorService.Orchestrate(flags); err != nil {
 		return fmt.Errorf("orchestration failed: %w", err)

--- a/mocks/output_service.go
+++ b/mocks/output_service.go
@@ -1,0 +1,32 @@
+package mocks
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/elC0mpa/aws-doctor/model"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockOutputService is a mock implementation of the output service interface.
+type MockOutputService struct {
+	mock.Mock
+}
+
+func (m *MockOutputService) RenderCostComparison(accountID, lastTotalCost, currentTotalCost string, lastMonth, currentMonth *model.CostInfo) error {
+	args := m.Called(accountID, lastTotalCost, currentTotalCost, lastMonth, currentMonth)
+	return args.Error(0)
+}
+
+func (m *MockOutputService) RenderTrend(accountID string, costInfo []model.CostInfo) error {
+	args := m.Called(accountID, costInfo)
+	return args.Error(0)
+}
+
+func (m *MockOutputService) RenderWaste(accountID string, elasticIPs []types.Address, unusedVolumes []types.Volume, stoppedVolumes []types.Volume, ris []model.RiExpirationInfo, stoppedInstances []types.Instance, loadBalancers []elbtypes.LoadBalancer, unusedAMIs []model.AMIWasteInfo, orphanedSnapshots []model.SnapshotWasteInfo) error {
+	args := m.Called(accountID, elasticIPs, unusedVolumes, stoppedVolumes, ris, stoppedInstances, loadBalancers, unusedAMIs, orphanedSnapshots)
+	return args.Error(0)
+}
+
+func (m *MockOutputService) StopSpinner() {
+	m.Called()
+}

--- a/service/orchestrator/types.go
+++ b/service/orchestrator/types.go
@@ -5,14 +5,16 @@ import (
 	awscostexplorer "github.com/elC0mpa/aws-doctor/service/costexplorer"
 	awsec2 "github.com/elC0mpa/aws-doctor/service/ec2"
 	"github.com/elC0mpa/aws-doctor/service/elb"
+	"github.com/elC0mpa/aws-doctor/service/output"
 	awssts "github.com/elC0mpa/aws-doctor/service/sts"
 )
 
 type service struct {
-	stsService  awssts.STSService
-	costService awscostexplorer.CostService
-	ec2Service  awsec2.EC2Service
-	elbService  elb.ELBService
+	stsService    awssts.STSService
+	costService   awscostexplorer.CostService
+	ec2Service    awsec2.EC2Service
+	elbService    elb.ELBService
+	outputService output.Service
 }
 
 type OrchestratorService interface {

--- a/service/output/service.go
+++ b/service/output/service.go
@@ -1,0 +1,54 @@
+package output
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/elC0mpa/aws-doctor/model"
+	"github.com/elC0mpa/aws-doctor/utils"
+)
+
+// NewService creates a new output service with the specified format
+func NewService(format string) Service {
+	f := FormatTable
+	if format == "json" {
+		f = FormatJSON
+	}
+	return &service{format: f}
+}
+
+func (s *service) RenderCostComparison(accountID, lastTotalCost, currentTotalCost string, lastMonth, currentMonth *model.CostInfo) error {
+	if s.format == FormatJSON {
+		return utils.OutputCostComparisonJSON(
+			accountID,
+			utils.ParseCostString(lastTotalCost),
+			utils.ParseCostString(currentTotalCost),
+			lastMonth,
+			currentMonth,
+		)
+	}
+
+	utils.DrawCostTable(accountID, lastTotalCost, currentTotalCost, lastMonth, currentMonth, "UnblendedCost")
+	return nil
+}
+
+func (s *service) RenderTrend(accountID string, costInfo []model.CostInfo) error {
+	if s.format == FormatJSON {
+		return utils.OutputTrendJSON(accountID, costInfo)
+	}
+
+	utils.DrawTrendChart(accountID, costInfo)
+	return nil
+}
+
+func (s *service) RenderWaste(accountID string, elasticIPs []types.Address, unusedVolumes []types.Volume, stoppedVolumes []types.Volume, ris []model.RiExpirationInfo, stoppedInstances []types.Instance, loadBalancers []elbtypes.LoadBalancer, unusedAMIs []model.AMIWasteInfo, orphanedSnapshots []model.SnapshotWasteInfo) error {
+	if s.format == FormatJSON {
+		return utils.OutputWasteJSON(accountID, elasticIPs, unusedVolumes, stoppedVolumes, ris, stoppedInstances, loadBalancers, unusedAMIs, orphanedSnapshots)
+	}
+
+	utils.DrawWasteTable(accountID, elasticIPs, unusedVolumes, stoppedVolumes, ris, stoppedInstances, loadBalancers, unusedAMIs, orphanedSnapshots)
+	return nil
+}
+
+func (s *service) StopSpinner() {
+	utils.StopSpinner()
+}

--- a/service/output/service_test.go
+++ b/service/output/service_test.go
@@ -1,0 +1,60 @@
+package output
+
+import (
+	"testing"
+)
+
+func TestNewService(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputFormat    string
+		expectedFormat Format
+	}{
+		{
+			name:           "json format",
+			inputFormat:    "json",
+			expectedFormat: FormatJSON,
+		},
+		{
+			name:           "table format explicit",
+			inputFormat:    "table",
+			expectedFormat: FormatTable,
+		},
+		{
+			name:           "empty string defaults to table",
+			inputFormat:    "",
+			expectedFormat: FormatTable,
+		},
+		{
+			name:           "unknown format defaults to table",
+			inputFormat:    "unknown",
+			expectedFormat: FormatTable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := NewService(tt.inputFormat)
+
+			// Type assert to access internal format field
+			s, ok := svc.(*service)
+			if !ok {
+				t.Fatal("NewService did not return *service type")
+			}
+
+			if s.format != tt.expectedFormat {
+				t.Errorf("expected format %q, got %q", tt.expectedFormat, s.format)
+			}
+		})
+	}
+}
+
+func TestFormatConstants(t *testing.T) {
+	if FormatTable != "table" {
+		t.Errorf("FormatTable should be 'table', got %q", FormatTable)
+	}
+
+	if FormatJSON != "json" {
+		t.Errorf("FormatJSON should be 'json', got %q", FormatJSON)
+	}
+}

--- a/service/output/types.go
+++ b/service/output/types.go
@@ -1,0 +1,35 @@
+package output
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/elC0mpa/aws-doctor/model"
+)
+
+// Format represents the output format type
+type Format string
+
+const (
+	FormatTable Format = "table"
+	FormatJSON  Format = "json"
+)
+
+// service is the internal implementation
+type service struct {
+	format Format
+}
+
+// Service defines the interface for output operations
+type Service interface {
+	// RenderCostComparison outputs cost comparison data in the configured format
+	RenderCostComparison(accountID, lastTotalCost, currentTotalCost string, lastMonth, currentMonth *model.CostInfo) error
+
+	// RenderTrend outputs trend data in the configured format
+	RenderTrend(accountID string, costInfo []model.CostInfo) error
+
+	// RenderWaste outputs waste report data in the configured format
+	RenderWaste(accountID string, elasticIPs []types.Address, unusedVolumes []types.Volume, stoppedVolumes []types.Volume, ris []model.RiExpirationInfo, stoppedInstances []types.Instance, loadBalancers []elbtypes.LoadBalancer, unusedAMIs []model.AMIWasteInfo, orphanedSnapshots []model.SnapshotWasteInfo) error
+
+	// StopSpinner stops the loading spinner before rendering output
+	StopSpinner()
+}


### PR DESCRIPTION
## Summary

- Create `service/output` package with `OutputService` interface to encapsulate all output formatting logic
- Move output format decision (table vs JSON) from orchestrator to dedicated service
- Update orchestrator to use `OutputService` instead of direct `utils` calls, removing scattered format conditionals

## Changes

- **New files:**
  - `service/output/types.go` - Interface definition and `Format` type
  - `service/output/service.go` - Implementation that delegates to existing utils functions
  - `service/output/service_test.go` - Unit tests for format parsing
  - `mocks/output_service.go` - Mock for testing

- **Modified files:**
  - `service/orchestrator/types.go` - Add `outputService` field
  - `service/orchestrator/service.go` - Use `OutputService` instead of direct utils calls
  - `service/orchestrator/service_test.go` - Update tests to include mock OutputService
  - `app.go` - Wire up `OutputService` with the orchestrator

## Benefits

- Better separation of concerns - orchestrator no longer knows about output formats
- Easier to add new output formats (CSV, YAML, etc.) in the future
- Improved testability - output can be mocked in orchestrator tests
- Follows existing service pattern in the codebase

## Test plan

- [x] All existing tests pass
- [x] New unit tests for OutputService format parsing
- [x] Build succeeds

Closes #25

---
Generated with [Claude Code](https://claude.ai/code)