### PR TITLE
Fix terminal cursor disappearing with --help flag

### DIFF
--- a/app.go
+++ b/app.go
@@ -23,7 +23,6 @@ var (
 
 func main() {
 	if err := run(); err != nil {
-		utils.StopSpinner()
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
@@ -40,13 +39,15 @@ func run() error {
 	}
 
 	utils.DrawBanner()
-	utils.StartSpinner()
 
 	flagService := flag.NewService()
 	flags, err := flagService.GetParsedFlags()
 	if err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
 	}
+
+	utils.StartSpinner()
+	defer utils.StopSpinner()
 
 	cfgService := awsconfig.NewService()
 	awsCfg, err := cfgService.GetAWSCfg(context.Background(), flags.Region, flags.Profile)


### PR DESCRIPTION
Closes #40 

- Move spinner initialization to after flag parsing so the cursor is never hidden when `--help` exits early
- Add `defer StopSpinner()` to ensure proper cleanup on all code paths

## Tests

```
➜  aws-doctor git:(main) ✗ go test ./...
ok  	github.com/elC0mpa/aws-doctor	(cached)
?   	github.com/elC0mpa/aws-doctor/mocks	[no test files]
?   	github.com/elC0mpa/aws-doctor/model	[no test files]
?   	github.com/elC0mpa/aws-doctor/service/aws_config	[no test files]
ok  	github.com/elC0mpa/aws-doctor/service/costexplorer	(cached)
ok  	github.com/elC0mpa/aws-doctor/service/ec2	(cached)
?   	github.com/elC0mpa/aws-doctor/service/elb	[no test files]
?   	github.com/elC0mpa/aws-doctor/service/flag	[no test files]
ok  	github.com/elC0mpa/aws-doctor/service/orchestrator	(cached)
?   	github.com/elC0mpa/aws-doctor/service/sts	[no test files]
ok  	github.com/elC0mpa/aws-doctor/utils	(cached)
```