### PR TITLE
fix: correct banner centering for Unicode characters

### DIFF
--- a/utils/banner/banner.go
+++ b/utils/banner/banner.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/elC0mpa/aws-doctor/utils/ansi"
 	"github.com/elC0mpa/aws-doctor/utils/console"
+	"github.com/mattn/go-runewidth"
 	"golang.org/x/term"
 )
 
@@ -99,9 +100,10 @@ var titleLines = []string{
 func printCenteredLines(lines []string, width int) {
 	for _, line := range lines {
 		pad := 0
+		lineWidth := runewidth.StringWidth(line)
 
-		if width > len(line) {
-			pad = (width - len(line)) / 2
+		if width > lineWidth {
+			pad = (width - lineWidth) / 2
 		}
 
 		if pad > 0 {


### PR DESCRIPTION
## Summary
- Fix banner centering calculation that used `len()` (byte count) instead of display width
- Unicode box-drawing characters are 3 bytes each in UTF-8, causing inconsistent padding across lines
- Use `runewidth.StringWidth()` for accurate visual width measurement

## Test plan
- [x] Existing banner tests pass
- [ ] Verify banner displays centered correctly in terminals of various widths