### PR TITLE
fix: filter ListBuckets by region to avoid cross-region PermanentRedirect

### DIFF
--- a/mocks/awsinterfaces/s3.go
+++ b/mocks/awsinterfaces/s3.go
@@ -12,6 +12,13 @@ type MockS3Client struct {
 	mock.Mock
 }
 
+// Options mocks the Options method.
+func (m *MockS3Client) Options() s3.Options {
+	args := m.Called()
+
+	return args.Get(0).(s3.Options)
+}
+
 // ListBuckets mocks the ListBuckets API call.
 func (m *MockS3Client) ListBuckets(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
 	args := m.Called(ctx, params, optFns)

--- a/service/s3/service.go
+++ b/service/s3/service.go
@@ -20,7 +20,6 @@ func NewService(awsconfig aws.Config) Service {
 
 	return &service{
 		client: client,
-		region: awsconfig.Region,
 	}
 }
 
@@ -35,8 +34,8 @@ func (s *service) GetS3Waste(ctx context.Context) ([]model.S3BucketWasteInfo, []
 	g.SetLimit(10) // Limit concurrency to avoid hitting rate limits
 
 	input := &s3.ListBucketsInput{}
-	if s.region != "" {
-		input.BucketRegion = &s.region
+	if region := s.client.Options().Region; region != "" {
+		input.BucketRegion = &region
 	}
 
 	paginator := s3.NewListBucketsPaginator(s.client, input)

--- a/service/s3/service_test.go
+++ b/service/s3/service_test.go
@@ -24,6 +24,7 @@ func TestGetS3Waste_MultipartError(t *testing.T) {
 	ctx := context.Background()
 	mockClient := new(awsinterfaces.MockS3Client)
 
+	mockClient.On("Options").Return(s3.Options{Region: "us-east-1"})
 	mockClient.On("ListBuckets", mock.Anything, mock.Anything, mock.Anything).Return(&s3.ListBucketsOutput{
 		Buckets: []types.Bucket{
 			{Name: aws.String("test-bucket"), CreationDate: aws.Time(time.Now())},
@@ -106,6 +107,7 @@ func TestGetS3Waste(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := new(awsinterfaces.MockS3Client)
+			mockClient.On("Options").Return(s3.Options{Region: "us-east-1"})
 			tt.setupMocks(mockClient)
 
 			svc := &service{client: mockClient}

--- a/service/s3/types.go
+++ b/service/s3/types.go
@@ -9,6 +9,7 @@ import (
 
 // ClientAPI is the interface for the AWS S3 client methods used by the service.
 type ClientAPI interface {
+	Options() s3.Options
 	ListBuckets(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error)
 	GetBucketLifecycleConfiguration(ctx context.Context, params *s3.GetBucketLifecycleConfigurationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLifecycleConfigurationOutput, error)
 	ListMultipartUploads(ctx context.Context, params *s3.ListMultipartUploadsInput, optFns ...func(*s3.Options)) (*s3.ListMultipartUploadsOutput, error)
@@ -16,7 +17,6 @@ type ClientAPI interface {
 
 type service struct {
 	client ClientAPI
-	region string
 }
 
 // Service is the interface for AWS S3 service.


### PR DESCRIPTION
## Summary

Closes #104

Passes the configured region to `ListBucketsInput.BucketRegion` so only buckets in the target region are returned. This removes the need for per-bucket region overrides and aligns S3 scanning with how all other resource types are already scoped to a single region.

Changes:
- Added `region` field to the service struct, populated from `aws.Config.Region`
- Passes `region` to `ListBucketsInput.BucketRegion` to filter buckets at the source
- Removed all per-bucket region override logic from #105 (`regionOptFns`, variadic `optFns` on `countMultipartUploads`)

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `golangci-lint` passes with zero issues
- [x] Build succeeds (`go build ./...`)
- [x] Verified against a real AWS account with buckets across multiple regions -- cross-region buckets are filtered out, no more PermanentRedirect errors