### PR TITLE
feat: show attached instance ID for EBS volumes on stopped instances

### DIFF
--- a/model/output_json.go
+++ b/model/output_json.go
@@ -137,6 +137,7 @@ type ElasticIPJSON struct {
 // EBSVolumeJSON represents an EBS volume
 type EBSVolumeJSON struct {
 	VolumeID             string  `json:"volume_id"`
+	AttachedInstanceID   string  `json:"attached_instance_id,omitempty"`
 	Size                 int32   `json:"size_gib"`
 	Status               string  `json:"status"`
 	EstimatedMonthlyCost float64 `json:"estimated_monthly_cost"`

--- a/utils/json_output/json_output.go
+++ b/utils/json_output/json_output.go
@@ -173,12 +173,18 @@ func mapEBSVolumes(volumes []types.Volume, status string) []model.EBSVolumeJSON 
 	for _, vol := range volumes {
 		size := aws.ToInt32(vol.Size)
 
-		result = append(result, model.EBSVolumeJSON{
+		entry := model.EBSVolumeJSON{
 			VolumeID:             aws.ToString(vol.VolumeId),
 			Size:                 size,
 			Status:               status,
 			EstimatedMonthlyCost: pricing.CalculateEBSMonthlyCost(size, vol.VolumeType),
-		})
+		}
+
+		if len(vol.Attachments) > 0 && vol.Attachments[0].InstanceId != nil {
+			entry.AttachedInstanceID = aws.ToString(vol.Attachments[0].InstanceId)
+		}
+
+		result = append(result, entry)
 	}
 
 	return result

--- a/utils/json_output/json_output.go
+++ b/utils/json_output/json_output.go
@@ -180,7 +180,7 @@ func mapEBSVolumes(volumes []types.Volume, status string) []model.EBSVolumeJSON 
 			EstimatedMonthlyCost: pricing.CalculateEBSMonthlyCost(size, vol.VolumeType),
 		}
 
-		if len(vol.Attachments) > 0 && vol.Attachments[0].InstanceId != nil {
+		if len(vol.Attachments) > 0 {
 			entry.AttachedInstanceID = aws.ToString(vol.Attachments[0].InstanceId)
 		}
 

--- a/utils/output_shared/waste_presenters.go
+++ b/utils/output_shared/waste_presenters.go
@@ -68,8 +68,10 @@ func PresentEBSVolume(vol types.Volume, status string) ResourceRow {
 
 // AttachedInstanceID returns the instance ID a volume is attached to, or NAValue if none.
 func AttachedInstanceID(vol types.Volume) string {
-	if len(vol.Attachments) > 0 && vol.Attachments[0].InstanceId != nil {
-		return aws.ToString(vol.Attachments[0].InstanceId)
+	if len(vol.Attachments) > 0 {
+		if id := aws.ToString(vol.Attachments[0].InstanceId); id != "" {
+			return id
+		}
 	}
 
 	return NAValue

--- a/utils/output_shared/waste_presenters.go
+++ b/utils/output_shared/waste_presenters.go
@@ -48,16 +48,31 @@ func PresentElasticIP(ip types.Address) ResourceRow {
 	}
 }
 
-// PresentEBSVolume returns a ResourceRow for an EBS volume
+// PresentEBSVolume returns a ResourceRow for an EBS volume.
+// When the volume is attached to an instance, the instance ID is appended to the identifier.
 func PresentEBSVolume(vol types.Volume, status string) ResourceRow {
+	identifier := aws.ToString(vol.VolumeId)
+	if instanceID := AttachedInstanceID(vol); instanceID != NAValue {
+		identifier = fmt.Sprintf("%s (%s)", identifier, instanceID)
+	}
+
 	return ResourceRow{
 		Category:      fmt.Sprintf("EBS Volume (%s)", status),
-		Identifier:    aws.ToString(vol.VolumeId),
+		Identifier:    identifier,
 		EstimatedCost: fmt.Sprintf("$%.2f", pricing.CalculateEBSMonthlyCost(aws.ToInt32(vol.Size), vol.VolumeType)),
 		Metric:        fmt.Sprintf("%d GiB", aws.ToInt32(vol.Size)),
 		Age:           NAValue,
 		Details:       fmt.Sprintf("State: %s, Created on %s", vol.State, vol.CreateTime.Format(time.RFC3339)),
 	}
+}
+
+// AttachedInstanceID returns the instance ID a volume is attached to, or NAValue if none.
+func AttachedInstanceID(vol types.Volume) string {
+	if len(vol.Attachments) > 0 && vol.Attachments[0].InstanceId != nil {
+		return aws.ToString(vol.Attachments[0].InstanceId)
+	}
+
+	return NAValue
 }
 
 // PresentStoppedInstance returns a ResourceRow for a stopped EC2 instance

--- a/utils/output_shared/waste_presenters_test.go
+++ b/utils/output_shared/waste_presenters_test.go
@@ -52,6 +52,7 @@ func TestPresentEBSVolume(t *testing.T) {
 		vol            types.Volume
 		status         string
 		wantIdentifier string
+		wantMetric     string
 	}{
 		{
 			name: "unattached_volume",
@@ -63,6 +64,7 @@ func TestPresentEBSVolume(t *testing.T) {
 			},
 			status:         "unattached",
 			wantIdentifier: "vol-12345",
+			wantMetric:     "100 GiB",
 		},
 		{
 			name: "attached_to_stopped_instance",
@@ -77,6 +79,7 @@ func TestPresentEBSVolume(t *testing.T) {
 			},
 			status:         "stopped",
 			wantIdentifier: "vol-67890 (i-abcdef)",
+			wantMetric:     "50 GiB",
 		},
 	}
 
@@ -90,6 +93,10 @@ func TestPresentEBSVolume(t *testing.T) {
 
 			if !strings.HasPrefix(p.EstimatedCost, "$") {
 				t.Errorf("EstimatedCost %q does not start with $", p.EstimatedCost)
+			}
+
+			if p.Metric != tt.wantMetric {
+				t.Errorf("Metric = %v, want %v", p.Metric, tt.wantMetric)
 			}
 		})
 	}
@@ -114,6 +121,15 @@ func TestAttachedInstanceID(t *testing.T) {
 				},
 			},
 			want: "i-12345",
+		},
+		{
+			name: "empty_instance_id",
+			vol: types.Volume{
+				Attachments: []types.VolumeAttachment{
+					{InstanceId: aws.String("")},
+				},
+			},
+			want: NAValue,
 		},
 		{
 			name: "nil_instance_id",

--- a/utils/output_shared/waste_presenters_test.go
+++ b/utils/output_shared/waste_presenters_test.go
@@ -48,19 +48,35 @@ func TestPresentS3MultipartUpload(t *testing.T) {
 
 func TestPresentEBSVolume(t *testing.T) {
 	tests := []struct {
-		name   string
-		vol    types.Volume
-		status string
+		name           string
+		vol            types.Volume
+		status         string
+		wantIdentifier string
 	}{
 		{
-			name: "single_volume",
+			name: "unattached_volume",
 			vol: types.Volume{
 				VolumeId:   aws.String("vol-12345"),
 				Size:       aws.Int32(100),
 				State:      types.VolumeStateAvailable,
 				CreateTime: aws.Time(time.Now()),
 			},
-			status: "unattached",
+			status:         "unattached",
+			wantIdentifier: "vol-12345",
+		},
+		{
+			name: "attached_to_stopped_instance",
+			vol: types.Volume{
+				VolumeId:   aws.String("vol-67890"),
+				Size:       aws.Int32(50),
+				State:      types.VolumeStateInUse,
+				CreateTime: aws.Time(time.Now()),
+				Attachments: []types.VolumeAttachment{
+					{InstanceId: aws.String("i-abcdef")},
+				},
+			},
+			status:         "stopped",
+			wantIdentifier: "vol-67890 (i-abcdef)",
 		},
 	}
 
@@ -68,16 +84,53 @@ func TestPresentEBSVolume(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := PresentEBSVolume(tt.vol, tt.status)
 
-			if p.Identifier != *tt.vol.VolumeId {
-				t.Errorf("Identifier = %v, want %v", p.Identifier, *tt.vol.VolumeId)
+			if p.Identifier != tt.wantIdentifier {
+				t.Errorf("Identifier = %v, want %v", p.Identifier, tt.wantIdentifier)
 			}
 
 			if !strings.HasPrefix(p.EstimatedCost, "$") {
 				t.Errorf("EstimatedCost %q does not start with $", p.EstimatedCost)
 			}
+		})
+	}
+}
 
-			if p.Metric != "100 GiB" {
-				t.Errorf("Metric = %v, want '100 GiB'", p.Metric)
+func TestAttachedInstanceID(t *testing.T) {
+	tests := []struct {
+		name string
+		vol  types.Volume
+		want string
+	}{
+		{
+			name: "no_attachments",
+			vol:  types.Volume{},
+			want: NAValue,
+		},
+		{
+			name: "with_attachment",
+			vol: types.Volume{
+				Attachments: []types.VolumeAttachment{
+					{InstanceId: aws.String("i-12345")},
+				},
+			},
+			want: "i-12345",
+		},
+		{
+			name: "nil_instance_id",
+			vol: types.Volume{
+				Attachments: []types.VolumeAttachment{
+					{InstanceId: nil},
+				},
+			},
+			want: NAValue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AttachedInstanceID(tt.vol)
+			if got != tt.want {
+				t.Errorf("AttachedInstanceID() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Closes #94

- EBS volumes attached to stopped instances now display the parent instance ID alongside the volume ID (e.g. `vol-xxx (i-xxx)`) across all output formats (table, CSV, JSON, PDF)
- JSON output adds a dedicated `attached_instance_id` field to `EBSVolumeJSON`
- Unattached volumes are unchanged

### Example CSV output

```
Resource Category,Resource Identifier,Estimated Monthly Cost (USD),Metric / Size,Age (Days),Additional Details
EBS Volume (stopped),vol-0abc1234def56789 (i-0abc1234def56789),$4.00,50 GiB,-,"State: in-use, Created on 2023-04-12T18:57:03Z"
EBS Volume (unattached),vol-0def5678abc12345,$0.64,8 GiB,-,"State: available, Created on 2024-01-17T20:05:01Z"
```

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] Added tests for `AttachedInstanceID` and updated `TestPresentEBSVolume` with attached volume case
- [x] Verified CSV, table, and JSON output manually against live AWS account