### PR TITLE
[BUG]: update command doesn't check current version #111

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ aws-doctor is a Go CLI tool that provides AWS cost analysis and waste detection.
 - 6-month trend analysis
 - Waste detection (unused EIPs, EBS volumes, stopped instances, load balancers, etc.)
 - Startup banner uses ANSI truecolor; title color switches to AmazonOrange when a blue background is detected (Windows console attributes or `COLORFGBG` on Unix-like terminals), otherwise SkypeBlue. Override with `AWS_DOCTOR_BANNER_COLOR` (color name or ANSI code).
+- `aws-doctor update` must check the latest GitHub release before running the install script. If the current binary is managed by Homebrew, it must print the package-manager upgrade command instead of attempting an in-place overwrite.
 
 ## Quick Reference
 
@@ -43,6 +44,7 @@ aws-doctor/
 |   |-- elb/              # ELB service (load balancers)
 |   |-- orchestrator/     # Workflow coordination
 |   |-- output/           # Output rendering (table/json) + spinner control
+|   |-- release/          # GitHub release lookup service
 |   |-- sts/              # AWS STS service
 |   |-- update/           # Self-update workflow
 |-- utils/                # Utility functions, table rendering
@@ -59,7 +61,9 @@ aws-doctor/
 - `cmd/` package defines Cobra commands (e.g., `cmd/waste.go`), initializes AWS services, and invokes `service/orchestrator`.
 - `service/orchestrator` executes the workflow logic by calling service methods based on the configured model.Flags.
 - `service/output` chooses between table and JSON rendering and owns spinner stop.
-- `service/update` handles updates (invoked by `cmd/update.go`).
+- `service/release` resolves the latest published GitHub release metadata.
+- `service/update` handles updates (invoked by `cmd/update.go`) and delegates release lookup to `service/release`.
+- Update flow should remain in `service/update` and keep the same DI pattern used by the rest of the project (interfaces in `types.go`, implementation in `service.go`, mocks in tests).
 
 ### Service Pattern
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ curl -sSfL https://raw.githubusercontent.com/elC0mpa/aws-doctor/main/install.sh 
 go install github.com/elC0mpa/aws-doctor@latest
 ```
 
+**Updating an existing installation:**
+
+```bash
+aws-doctor update
+```
+
+`aws-doctor update` now checks the latest published GitHub release before downloading anything. The version comparison is resolved from the release metadata, not from a tags endpoint. If the current binary was installed with Homebrew, the command will stop and tell you to use `brew upgrade aws-doctor` instead of trying to overwrite a Homebrew-managed binary.
+
 ## ✨ Key Features
 
 - **📄 Professional PDF Reports:** Generate branded, ready-to-share PDF documents for costs, trends, and waste analysis.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/elC0mpa/aws-doctor/service/orchestrator"
 	"github.com/elC0mpa/aws-doctor/service/output"
 	"github.com/elC0mpa/aws-doctor/service/rds"
+	"github.com/elC0mpa/aws-doctor/service/release"
 	"github.com/elC0mpa/aws-doctor/service/report"
 	"github.com/elC0mpa/aws-doctor/service/s3"
 	awssts "github.com/elC0mpa/aws-doctor/service/sts"
@@ -33,7 +34,8 @@ var (
 
 func buildOrchestrator(needsAWS bool) (orchestrator.Service, error) {
 	outputService := output.NewService(outputFormat)
-	updateService := update.NewService()
+	releaseService := release.NewService()
+	updateService := update.NewService(versionInfo.Version, releaseService)
 
 	config := orchestrator.Config{
 		OutputService: outputService,

--- a/docs/content/docs/usage/_index.es.md
+++ b/docs/content/docs/usage/_index.es.md
@@ -72,4 +72,4 @@ Mantenga su motor de diagnóstico actualizado con un solo comando:
 ```bash
 aws-doctor update
 ```
-Esto buscará el último lanzamiento en GitHub, descargará el binario para su plataforma y reemplazará el existente.
+Este comando consulta la última GitHub release publicada antes de descargar nada. La versión se resuelve desde los metadatos de la release y no desde un endpoint de tags. Si ya tienes la versión más reciente, termina sin reinstalar. Si el binario actual está administrado por Homebrew, mostrará `brew upgrade aws-doctor` en lugar de intentar sobrescribir la instalación administrada por Homebrew.

--- a/docs/content/docs/usage/_index.md
+++ b/docs/content/docs/usage/_index.md
@@ -73,4 +73,4 @@ Keep your diagnostic engine up to date with a single command:
 ```bash
 aws-doctor update
 ```
-This will check GitHub for the latest release, download the binary for your platform, and replace the existing one.
+This command checks the latest published GitHub release before downloading anything. It resolves the version from the release metadata instead of querying a tags endpoint. If you already have the latest version, it exits without reinstalling. If the current binary is managed by Homebrew, it prints `brew upgrade aws-doctor` instead of trying to overwrite the Homebrew-managed installation.

--- a/model/release.go
+++ b/model/release.go
@@ -1,0 +1,8 @@
+package model
+
+// ReleaseInfo contains metadata for a published application release.
+type ReleaseInfo struct {
+	Version string
+	Name    string
+	URL     string
+}

--- a/service/release/service.go
+++ b/service/release/service.go
@@ -22,6 +22,7 @@ type realGitHubClient struct {
 
 type latestReleaseResponse struct {
 	Name    string `json:"name"`
+	TagName string `json:"tag_name"`
 	HTMLURL string `json:"html_url"`
 }
 
@@ -40,7 +41,7 @@ func (s *service) GetLatestRelease(ctx context.Context) (model.ReleaseInfo, erro
 		return model.ReleaseInfo{}, err
 	}
 
-	version, err := versionFromReleaseName(release.Name)
+	version, err := versionFromRelease(release)
 	if err != nil {
 		return model.ReleaseInfo{}, err
 	}
@@ -76,20 +77,26 @@ func (c *realGitHubClient) LatestRelease(ctx context.Context) (githubRelease, er
 		return githubRelease{}, fmt.Errorf("decode latest release response: %w", err)
 	}
 
-	if strings.TrimSpace(payload.Name) == "" {
-		return githubRelease{}, fmt.Errorf("latest release name is empty")
+	if strings.TrimSpace(payload.Name) == "" && strings.TrimSpace(payload.TagName) == "" {
+		return githubRelease{}, fmt.Errorf("latest release name and tag are empty")
 	}
 
 	return githubRelease{
-		Name: payload.Name,
-		URL:  payload.HTMLURL,
+		Name:    payload.Name,
+		TagName: payload.TagName,
+		URL:     payload.HTMLURL,
 	}, nil
 }
 
-func versionFromReleaseName(name string) (string, error) {
-	match := releaseVersionPattern.FindString(strings.TrimSpace(name))
+func versionFromRelease(release githubRelease) (string, error) {
+	source := strings.TrimSpace(release.Name)
+	if source == "" {
+		source = strings.TrimSpace(release.TagName)
+	}
+
+	match := releaseVersionPattern.FindString(source)
 	if match == "" {
-		return "", fmt.Errorf("latest release name does not include a version: %q", name)
+		return "", fmt.Errorf("latest release metadata does not include a version: name=%q tag=%q", release.Name, release.TagName)
 	}
 
 	return normalizeVersion(match), nil

--- a/service/release/service.go
+++ b/service/release/service.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/elC0mpa/aws-doctor/model"
 )
@@ -30,7 +31,9 @@ type latestReleaseResponse struct {
 func NewService() Service {
 	return &service{
 		client: &realGitHubClient{
-			client: http.DefaultClient,
+			client: &http.Client{
+				Timeout: 10 * time.Second,
+			},
 		},
 	}
 }

--- a/service/release/service.go
+++ b/service/release/service.go
@@ -1,0 +1,100 @@
+// Package release provides access to published GitHub releases for aws-doctor.
+package release
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/elC0mpa/aws-doctor/model"
+)
+
+const latestReleaseURL = "https://api.github.com/repos/elC0mpa/aws-doctor/releases/latest"
+
+var releaseVersionPattern = regexp.MustCompile(`v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?`)
+
+type realGitHubClient struct {
+	client *http.Client
+}
+
+type latestReleaseResponse struct {
+	Name    string `json:"name"`
+	HTMLURL string `json:"html_url"`
+}
+
+// NewService creates a new release service.
+func NewService() Service {
+	return &service{
+		client: &realGitHubClient{
+			client: http.DefaultClient,
+		},
+	}
+}
+
+func (s *service) GetLatestRelease(ctx context.Context) (model.ReleaseInfo, error) {
+	release, err := s.client.LatestRelease(ctx)
+	if err != nil {
+		return model.ReleaseInfo{}, err
+	}
+
+	version, err := versionFromReleaseName(release.Name)
+	if err != nil {
+		return model.ReleaseInfo{}, err
+	}
+
+	return model.ReleaseInfo{
+		Version: version,
+		Name:    release.Name,
+		URL:     release.URL,
+	}, nil
+}
+
+func (c *realGitHubClient) LatestRelease(ctx context.Context) (githubRelease, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestReleaseURL, nil)
+	if err != nil {
+		return githubRelease{}, fmt.Errorf("create latest release request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "aws-doctor")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return githubRelease{}, fmt.Errorf("request latest release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return githubRelease{}, fmt.Errorf("unexpected GitHub status: %s", resp.Status)
+	}
+
+	var payload latestReleaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return githubRelease{}, fmt.Errorf("decode latest release response: %w", err)
+	}
+
+	if strings.TrimSpace(payload.Name) == "" {
+		return githubRelease{}, fmt.Errorf("latest release name is empty")
+	}
+
+	return githubRelease{
+		Name: payload.Name,
+		URL:  payload.HTMLURL,
+	}, nil
+}
+
+func versionFromReleaseName(name string) (string, error) {
+	match := releaseVersionPattern.FindString(strings.TrimSpace(name))
+	if match == "" {
+		return "", fmt.Errorf("latest release name does not include a version: %q", name)
+	}
+
+	return normalizeVersion(match), nil
+}
+
+func normalizeVersion(version string) string {
+	return strings.TrimPrefix(strings.TrimSpace(version), "v")
+}

--- a/service/release/service_test.go
+++ b/service/release/service_test.go
@@ -1,0 +1,113 @@
+package release
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/elC0mpa/aws-doctor/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockGitHubClient struct {
+	mock.Mock
+}
+
+func (m *mockGitHubClient) LatestRelease(ctx context.Context) (githubRelease, error) {
+	args := m.Called(ctx)
+
+	releaseValue, _ := args.Get(0).(githubRelease)
+
+	return releaseValue, args.Error(1)
+}
+
+func TestNewService(t *testing.T) {
+	svc := NewService()
+	assert.NotNil(t, svc)
+
+	impl, ok := svc.(*service)
+	assert.True(t, ok)
+	assert.NotNil(t, impl.client)
+}
+
+func TestGetLatestRelease(t *testing.T) {
+	tests := []struct {
+		name        string
+		release     githubRelease
+		clientErr   error
+		want        model.ReleaseInfo
+		wantErrText string
+	}{
+		{
+			name: "returns version from release name",
+			release: githubRelease{
+				Name: "aws-doctor v2.6.4",
+				URL:  "https://github.com/elC0mpa/aws-doctor/releases/tag/v2.6.4",
+			},
+			want: model.ReleaseInfo{
+				Version: "2.6.4",
+				Name:    "aws-doctor v2.6.4",
+				URL:     "https://github.com/elC0mpa/aws-doctor/releases/tag/v2.6.4",
+			},
+		},
+		{
+			name:        "returns client error",
+			clientErr:   errors.New("network down"),
+			wantErrText: "network down",
+		},
+		{
+			name: "errors when release name has no version",
+			release: githubRelease{
+				Name: "aws-doctor stable",
+			},
+			wantErrText: `latest release name does not include a version: "aws-doctor stable"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := new(mockGitHubClient)
+			svc := &service{client: mc}
+
+			mc.On("LatestRelease", mock.Anything).Return(tt.release, tt.clientErr).Once()
+
+			got, err := svc.GetLatestRelease(context.Background())
+
+			if tt.wantErrText != "" {
+				assert.EqualError(t, err, tt.wantErrText)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+
+			mc.AssertExpectations(t)
+		})
+	}
+}
+
+func TestVersionFromReleaseName(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		want        string
+		wantErrText string
+	}{
+		{name: "extracts version with prefix", input: "aws-doctor v2.6.4", want: "2.6.4"},
+		{name: "extracts prerelease version", input: "Release v2.6.4-beta.1", want: "2.6.4-beta.1"},
+		{name: "errors when version missing", input: "latest stable", wantErrText: `latest release name does not include a version: "latest stable"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := versionFromReleaseName(tt.input)
+
+			if tt.wantErrText != "" {
+				assert.EqualError(t, err, tt.wantErrText)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/service/release/service_test.go
+++ b/service/release/service_test.go
@@ -42,12 +42,26 @@ func TestGetLatestRelease(t *testing.T) {
 		{
 			name: "returns version from release name",
 			release: githubRelease{
-				Name: "aws-doctor v2.6.4",
-				URL:  "https://github.com/elC0mpa/aws-doctor/releases/tag/v2.6.4",
+				Name:    "aws-doctor v2.6.4",
+				TagName: "v2.6.4",
+				URL:     "https://github.com/elC0mpa/aws-doctor/releases/tag/v2.6.4",
 			},
 			want: model.ReleaseInfo{
 				Version: "2.6.4",
 				Name:    "aws-doctor v2.6.4",
+				URL:     "https://github.com/elC0mpa/aws-doctor/releases/tag/v2.6.4",
+			},
+		},
+		{
+			name: "falls back to tag when release name is empty",
+			release: githubRelease{
+				Name:    "",
+				TagName: "v2.6.4",
+				URL:     "https://github.com/elC0mpa/aws-doctor/releases/tag/v2.6.4",
+			},
+			want: model.ReleaseInfo{
+				Version: "2.6.4",
+				Name:    "",
 				URL:     "https://github.com/elC0mpa/aws-doctor/releases/tag/v2.6.4",
 			},
 		},
@@ -57,11 +71,12 @@ func TestGetLatestRelease(t *testing.T) {
 			wantErrText: "network down",
 		},
 		{
-			name: "errors when release name has no version",
+			name: "errors when release metadata has no version",
 			release: githubRelease{
-				Name: "aws-doctor stable",
+				Name:    "aws-doctor stable",
+				TagName: "stable",
 			},
-			wantErrText: `latest release name does not include a version: "aws-doctor stable"`,
+			wantErrText: `latest release metadata does not include a version: name="aws-doctor stable" tag="stable"`,
 		},
 	}
 
@@ -86,21 +101,22 @@ func TestGetLatestRelease(t *testing.T) {
 	}
 }
 
-func TestVersionFromReleaseName(t *testing.T) {
+func TestVersionFromRelease(t *testing.T) {
 	tests := []struct {
 		name        string
-		input       string
+		input       githubRelease
 		want        string
 		wantErrText string
 	}{
-		{name: "extracts version with prefix", input: "aws-doctor v2.6.4", want: "2.6.4"},
-		{name: "extracts prerelease version", input: "Release v2.6.4-beta.1", want: "2.6.4-beta.1"},
-		{name: "errors when version missing", input: "latest stable", wantErrText: `latest release name does not include a version: "latest stable"`},
+		{name: "extracts version from release name", input: githubRelease{Name: "aws-doctor v2.6.4"}, want: "2.6.4"},
+		{name: "extracts prerelease version", input: githubRelease{Name: "Release v2.6.4-beta.1"}, want: "2.6.4-beta.1"},
+		{name: "falls back to tag name", input: githubRelease{TagName: "v2.6.4"}, want: "2.6.4"},
+		{name: "errors when version missing", input: githubRelease{Name: "latest stable", TagName: "stable"}, wantErrText: `latest release metadata does not include a version: name="latest stable" tag="stable"`},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := versionFromReleaseName(tt.input)
+			got, err := versionFromRelease(tt.input)
 
 			if tt.wantErrText != "" {
 				assert.EqualError(t, err, tt.wantErrText)

--- a/service/release/types.go
+++ b/service/release/types.go
@@ -1,0 +1,25 @@
+package release
+
+import (
+	"context"
+
+	"github.com/elC0mpa/aws-doctor/model"
+)
+
+type service struct {
+	client githubClient
+}
+
+type githubClient interface {
+	LatestRelease(ctx context.Context) (githubRelease, error)
+}
+
+type githubRelease struct {
+	Name string
+	URL  string
+}
+
+// Service fetches published release metadata.
+type Service interface {
+	GetLatestRelease(ctx context.Context) (model.ReleaseInfo, error)
+}

--- a/service/release/types.go
+++ b/service/release/types.go
@@ -15,8 +15,9 @@ type githubClient interface {
 }
 
 type githubRelease struct {
-	Name string
-	URL  string
+	Name    string
+	TagName string
+	URL     string
 }
 
 // Service fetches published release metadata.

--- a/service/update/service.go
+++ b/service/update/service.go
@@ -57,7 +57,7 @@ func (s *service) Update() error {
 	}
 
 	currentVersion := normalizeVersion(s.currentVersion)
-	if currentVersion != "" && currentVersion != "dev" && currentVersion == normalizeVersion(latestRelease.Version) {
+	if currentVersion != "" && currentVersion != "dev" && currentVersion == latestRelease.Version {
 		_, _ = fmt.Fprintf(s.stdout, "aws-doctor v%s is already the latest release.\n", latestRelease.Version)
 
 		return nil

--- a/service/update/service.go
+++ b/service/update/service.go
@@ -1,12 +1,20 @@
 package update
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	installScriptCommand = "curl -sSL https://raw.githubusercontent.com/elC0mpa/aws-doctor/main/install.sh | sh"
 )
 
 type realRunner struct{}
+type realExecutablePathResolver struct{}
 
 func (r *realRunner) Run(name string, arg ...string) error {
 	cmd := exec.Command(name, arg...)
@@ -17,18 +25,83 @@ func (r *realRunner) Run(name string, arg ...string) error {
 	return cmd.Run()
 }
 
+func (r *realExecutablePathResolver) ExecutablePath() (string, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolvedPath, nil
+	}
+
+	return path, nil
+}
+
 // NewService creates a new update service.
-func NewService() Service {
+func NewService(currentVersion string, releaseService releaseService) Service {
 	return &service{
-		runner: &realRunner{},
+		runner:         &realRunner{},
+		releaseService: releaseService,
+		pathResolver:   &realExecutablePathResolver{},
+		currentVersion: currentVersion,
+		stdout:         os.Stdout,
 	}
 }
 
 func (s *service) Update() error {
-	// Reutilize the install.sh script from the repository
-	if err := s.runner.Run("sh", "-c", "curl -sSL https://raw.githubusercontent.com/elC0mpa/aws-doctor/main/install.sh | sh"); err != nil {
+	latestRelease, err := s.releaseService.GetLatestRelease(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to fetch latest release version: %w", err)
+	}
+
+	currentVersion := normalizeVersion(s.currentVersion)
+	if currentVersion != "" && currentVersion != "dev" && currentVersion == normalizeVersion(latestRelease.Version) {
+		_, _ = fmt.Fprintf(s.stdout, "aws-doctor v%s is already the latest release.\n", latestRelease.Version)
+
+		return nil
+	}
+
+	if packageManager, ok, err := s.detectPackageManager(); err != nil {
+		return fmt.Errorf("failed to inspect current installation: %w", err)
+	} else if ok {
+		_, _ = fmt.Fprintf(s.stdout, "aws-doctor was installed via %s. Please update it with `%s`.\n", packageManager, updateCommandFor(packageManager))
+
+		return nil
+	}
+
+	// Reuse the install.sh script from the repository for direct script installs.
+	if err := s.runner.Run("sh", "-c", installScriptCommand); err != nil {
 		return fmt.Errorf("failed to run update script: %w", err)
 	}
 
 	return nil
+}
+
+func (s *service) detectPackageManager() (string, bool, error) {
+	executablePath, err := s.pathResolver.ExecutablePath()
+	if err != nil {
+		return "", false, err
+	}
+
+	normalizedPath := strings.ToLower(filepath.ToSlash(executablePath))
+
+	if strings.Contains(normalizedPath, "/cellar/") || strings.Contains(normalizedPath, "/homebrew/") || strings.Contains(normalizedPath, "/.linuxbrew/") {
+		return "Homebrew", true, nil
+	}
+
+	return "", false, nil
+}
+
+func updateCommandFor(packageManager string) string {
+	if packageManager == "Homebrew" {
+		return "brew upgrade aws-doctor"
+	}
+
+	return "your package manager's upgrade command"
+}
+
+func normalizeVersion(version string) string {
+	return strings.TrimPrefix(strings.TrimSpace(version), "v")
 }

--- a/service/update/service_test.go
+++ b/service/update/service_test.go
@@ -1,9 +1,12 @@
 package update
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"testing"
 
+	"github.com/elC0mpa/aws-doctor/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -18,37 +21,135 @@ func (m *mockRunner) Run(name string, arg ...string) error {
 	return args.Error(0)
 }
 
+type mockReleaseService struct {
+	mock.Mock
+}
+
+func (m *mockReleaseService) GetLatestRelease(ctx context.Context) (model.ReleaseInfo, error) {
+	args := m.Called(ctx)
+	releaseValue, _ := args.Get(0).(model.ReleaseInfo)
+	return releaseValue, args.Error(1)
+}
+
+type mockExecutablePathResolver struct {
+	mock.Mock
+}
+
+func (m *mockExecutablePathResolver) ExecutablePath() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
 func TestNewService(t *testing.T) {
-	svc := NewService()
+	svc := NewService("v1.2.3", &mockReleaseService{})
 	assert.NotNil(t, svc)
 
 	s, ok := svc.(*service)
 	assert.True(t, ok)
 	assert.NotNil(t, s.runner)
+	assert.NotNil(t, s.releaseService)
+	assert.NotNil(t, s.pathResolver)
+	assert.Equal(t, "v1.2.3", s.currentVersion)
+	assert.NotNil(t, s.stdout)
 }
 
-func TestUpdate_Success(t *testing.T) {
-	mr := new(mockRunner)
-	s := &service{runner: mr}
+func TestUpdate(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion string
+		latestRelease  model.ReleaseInfo
+		latestErr      error
+		executablePath string
+		pathErr        error
+		runErr         error
+		wantErr        string
+		wantOutput     string
+		expectRun      bool
+	}{
+		{
+			name:           "skips update when current version is latest",
+			currentVersion: "v1.2.3",
+			latestRelease:  model.ReleaseInfo{Version: "1.2.3", Name: "aws-doctor v1.2.3"},
+			executablePath: "/usr/local/bin/aws-doctor",
+			wantOutput:     "aws-doctor v1.2.3 is already the latest release.\n",
+		},
+		{
+			name:           "prints brew upgrade guidance for homebrew install",
+			currentVersion: "v1.2.2",
+			latestRelease:  model.ReleaseInfo{Version: "1.2.3", Name: "aws-doctor v1.2.3"},
+			executablePath: "/opt/homebrew/Cellar/aws-doctor/1.2.2/bin/aws-doctor",
+			wantOutput:     "aws-doctor was installed via Homebrew. Please update it with `brew upgrade aws-doctor`.\n",
+		},
+		{
+			name:           "runs install script when direct install is outdated",
+			currentVersion: "v1.2.2",
+			latestRelease:  model.ReleaseInfo{Version: "1.2.3", Name: "aws-doctor v1.2.3"},
+			executablePath: "/usr/local/bin/aws-doctor",
+			expectRun:      true,
+		},
+		{
+			name:           "returns error when release lookup fails",
+			currentVersion: "v1.2.2",
+			latestErr:      errors.New("github down"),
+			wantErr:        "failed to fetch latest release version: github down",
+		},
+		{
+			name:           "returns error when installation lookup fails",
+			currentVersion: "v1.2.2",
+			latestRelease:  model.ReleaseInfo{Version: "1.2.3", Name: "aws-doctor v1.2.3"},
+			pathErr:        errors.New("cannot resolve executable"),
+			wantErr:        "failed to inspect current installation: cannot resolve executable",
+		},
+		{
+			name:           "returns error when install script fails",
+			currentVersion: "v1.2.2",
+			latestRelease:  model.ReleaseInfo{Version: "1.2.3", Name: "aws-doctor v1.2.3"},
+			executablePath: "/usr/local/bin/aws-doctor",
+			runErr:         errors.New("execution failed"),
+			wantErr:        "failed to run update script: execution failed",
+			expectRun:      true,
+		},
+	}
 
-	mr.On("Run", "sh", []string{"-c", "curl -sSL https://raw.githubusercontent.com/elC0mpa/aws-doctor/main/install.sh | sh"}).Return(nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mr := new(mockRunner)
+			mc := new(mockReleaseService)
+			mp := new(mockExecutablePathResolver)
+			stdout := &bytes.Buffer{}
 
-	err := s.Update()
-	assert.NoError(t, err)
-	mr.AssertExpectations(t)
-}
+			s := &service{
+				runner:         mr,
+				releaseService: mc,
+				pathResolver:   mp,
+				currentVersion: tt.currentVersion,
+				stdout:         stdout,
+			}
 
-func TestUpdate_Error(t *testing.T) {
-	mr := new(mockRunner)
-	s := &service{runner: mr}
+			mc.On("GetLatestRelease", mock.Anything).Return(tt.latestRelease, tt.latestErr).Once()
 
-	mr.On("Run", "sh", []string{"-c", "curl -sSL https://raw.githubusercontent.com/elC0mpa/aws-doctor/main/install.sh | sh"}).Return(errors.New("execution failed"))
+			if tt.latestErr == nil && normalizeVersion(tt.currentVersion) != normalizeVersion(tt.latestRelease.Version) {
+				mp.On("ExecutablePath").Return(tt.executablePath, tt.pathErr).Once()
+			}
 
-	err := s.Update()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to run update script")
-	assert.Contains(t, err.Error(), "execution failed")
-	mr.AssertExpectations(t)
+			if tt.expectRun {
+				mr.On("Run", "sh", []string{"-c", installScriptCommand}).Return(tt.runErr).Once()
+			}
+
+			err := s.Update()
+
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantOutput, stdout.String())
+			mc.AssertExpectations(t)
+			mp.AssertExpectations(t)
+			mr.AssertExpectations(t)
+		})
+	}
 }
 
 func TestRealRunner_Run(t *testing.T) {
@@ -64,4 +165,22 @@ func TestRealRunner_Run_Error(t *testing.T) {
 	// Running a non-existent command should return an error
 	err := r.Run("non-existent-command-12345")
 	assert.Error(t, err)
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "keeps bare semver", version: "1.2.3", want: "1.2.3"},
+		{name: "trims v prefix", version: "v1.2.3", want: "1.2.3"},
+		{name: "trims whitespace", version: " v1.2.3\n", want: "1.2.3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeVersion(tt.version))
+		})
+	}
 }

--- a/service/update/types.go
+++ b/service/update/types.go
@@ -1,5 +1,12 @@
 package update
 
+import (
+	"context"
+	"io"
+
+	"github.com/elC0mpa/aws-doctor/model"
+)
+
 // Service is the interface for the update service.
 type Service interface {
 	Update() error
@@ -9,6 +16,18 @@ type commandRunner interface {
 	Run(name string, arg ...string) error
 }
 
+type releaseService interface {
+	GetLatestRelease(ctx context.Context) (model.ReleaseInfo, error)
+}
+
+type executablePathResolver interface {
+	ExecutablePath() (string, error)
+}
+
 type service struct {
-	runner commandRunner
+	runner         commandRunner
+	releaseService releaseService
+	pathResolver   executablePathResolver
+	currentVersion string
+	stdout         io.Writer
 }


### PR DESCRIPTION
## Description
This PR fixes the self-update flow so `aws-doctor update` no longer blindly reinstalls the binary every time.

The update workflow now:
- checks the latest published GitHub release before attempting any install
- skips the installer when the current version is already up to date
- detects Homebrew-managed installations and instructs the user to run `brew upgrade aws-doctor` instead of trying to overwrite a managed binary
- keeps the project architecture consistent by extracting GitHub release lookup into a dedicated `service/release` module and injecting it into `service/update`

Additionally, documentation and tests were updated to reflect the new behavior.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Fix (bug fix)
- [x] 📝 Documentation (updates to README, docs, or comments)
- [x] 🧹 Refactor (code improvement without functional changes)
- [x] 🧪 Test (adding or improving tests)
- [ ] 🔧 Chore (maintenance, CI/CD, build system)

## ⚠️ Important: Target Branch
This PR should target the **`development`** branch.

## Checklist
- [ ] I have rebased my branch against `upstream/development`.
- [x] My code follows the project's code style.
- [x] I have added unit tests to cover my changes.
- [x] I have updated the documentation (if applicable).
- [ ] All new and existing tests passed locally.

## Screenshots (if applicable)
No screenshots included.

Example CLI output when already up to date:

```bash
$ aws-doctor update
aws-doctor v2.6.4 is already the latest release.