### PR TITLE
perf(lambda): batch CloudWatch Logs Insights queries

### DIFF
--- a/mocks/services/cloudwatch_service.go
+++ b/mocks/services/cloudwatch_service.go
@@ -24,9 +24,24 @@ func (m *MockCloudWatchLogsService) GetCloudWatchLogsWaste(ctx context.Context) 
 	return args.Get(0).([]model.CloudWatchLogsWasteInfo), args.Error(1)
 }
 
-// GetLambdaMaxMemoryUsed mocks the GetLambdaMaxMemoryUsed method.
-func (m *MockCloudWatchLogsService) GetLambdaMaxMemoryUsed(ctx context.Context, logGroupName string, startTime, endTime time.Time) (int32, error) {
-	args := m.Called(ctx, logGroupName, startTime, endTime)
+// GetLambdaMaxMemoryUsedBatch mocks the GetLambdaMaxMemoryUsedBatch method.
+func (m *MockCloudWatchLogsService) GetLambdaMaxMemoryUsedBatch(ctx context.Context, logGroupNames []string, startTime, endTime time.Time) (map[string]int32, error) {
+	args := m.Called(ctx, logGroupNames, startTime, endTime)
 
-	return args.Get(0).(int32), args.Error(1)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(map[string]int32), args.Error(1)
+}
+
+// ListExistingLogGroups mocks the ListExistingLogGroups method.
+func (m *MockCloudWatchLogsService) ListExistingLogGroups(ctx context.Context, prefix string) (map[string]struct{}, error) {
+	args := m.Called(ctx, prefix)
+
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(map[string]struct{}), args.Error(1)
 }

--- a/service/cloudwatchlogs/service.go
+++ b/service/cloudwatchlogs/service.go
@@ -137,8 +137,8 @@ func parseMaxMemMBByGroup(results [][]cwlogstypes.ResultField) map[string]int32 
 			switch aws.ToString(field.Field) {
 			case "@log":
 				logValue := aws.ToString(field.Value)
-				if idx := strings.Index(logValue, ":"); idx >= 0 {
-					logGroup = logValue[idx+1:]
+				if _, after, ok := strings.Cut(logValue, ":"); ok {
+					logGroup = after
 				} else {
 					logGroup = logValue
 				}

--- a/service/cloudwatchlogs/service.go
+++ b/service/cloudwatchlogs/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -54,19 +55,50 @@ func (s *service) GetCloudWatchLogsWaste(ctx context.Context) ([]model.CloudWatc
 
 const queryPollInterval = 500 * time.Millisecond
 
-// GetLambdaMaxMemoryUsed runs a CloudWatch Logs Insights query to find the maximum memory used
-// by a Lambda function within the given time range. Returns the value in MB.
-func (s *service) GetLambdaMaxMemoryUsed(ctx context.Context, logGroupName string, startTime, endTime time.Time) (int32, error) {
-	queryString := `filter @type = "REPORT" | stats max(@maxMemoryUsed / 1048576) as maxMemMB`
+// ListExistingLogGroups returns the set of log group names matching the given name prefix. This
+// is used to pre-filter before calling GetLambdaMaxMemoryUsedBatch, since a StartQuery fails the
+// entire request when any named log group is missing.
+func (s *service) ListExistingLogGroups(ctx context.Context, prefix string) (map[string]struct{}, error) {
+	existing := make(map[string]struct{})
+
+	paginator := cloudwatchlogs.NewDescribeLogGroupsPaginator(s.client, &cloudwatchlogs.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String(prefix),
+	})
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to describe log groups: %w", err)
+		}
+
+		for _, lg := range output.LogGroups {
+			if lg.LogGroupName != nil {
+				existing[*lg.LogGroupName] = struct{}{}
+			}
+		}
+	}
+
+	return existing, nil
+}
+
+// GetLambdaMaxMemoryUsedBatch runs a single CloudWatch Logs Insights query against multiple log
+// groups and returns a map of log group name to the maximum memory used (in MB) within the given
+// time range. Log groups with no REPORT entries are omitted from the result.
+func (s *service) GetLambdaMaxMemoryUsedBatch(ctx context.Context, logGroupNames []string, startTime, endTime time.Time) (map[string]int32, error) {
+	if len(logGroupNames) == 0 {
+		return map[string]int32{}, nil
+	}
+
+	queryString := `filter @type = "REPORT" | stats max(@maxMemoryUsed / 1048576) as maxMemMB by @log`
 
 	startOutput, err := s.client.StartQuery(ctx, &cloudwatchlogs.StartQueryInput{
-		LogGroupName: aws.String(logGroupName),
-		StartTime:    aws.Int64(startTime.Unix()),
-		EndTime:      aws.Int64(endTime.Unix()),
-		QueryString:  aws.String(queryString),
+		LogGroupNames: logGroupNames,
+		StartTime:     aws.Int64(startTime.Unix()),
+		EndTime:       aws.Int64(endTime.Unix()),
+		QueryString:   aws.String(queryString),
 	})
 	if err != nil {
-		return 0, fmt.Errorf("failed to start query for %s: %w", logGroupName, err)
+		return nil, fmt.Errorf("failed to start query: %w", err)
 	}
 
 	for {
@@ -74,35 +106,55 @@ func (s *service) GetLambdaMaxMemoryUsed(ctx context.Context, logGroupName strin
 			QueryId: startOutput.QueryId,
 		})
 		if err != nil {
-			return 0, fmt.Errorf("failed to get query results for %s: %w", logGroupName, err)
+			return nil, fmt.Errorf("failed to get query results: %w", err)
 		}
 
 		if results.Status == cwlogstypes.QueryStatusComplete {
-			return parseMaxMemMB(results.Results), nil
+			return parseMaxMemMBByGroup(results.Results), nil
 		}
 
 		if results.Status == cwlogstypes.QueryStatusFailed || results.Status == cwlogstypes.QueryStatusCancelled || results.Status == cwlogstypes.QueryStatusTimeout {
-			return 0, fmt.Errorf("query %s for %s", results.Status, logGroupName)
+			return nil, fmt.Errorf("query %s", results.Status)
 		}
 
 		time.Sleep(queryPollInterval)
 	}
 }
 
-// parseMaxMemMB extracts the maxMemMB value from CW Logs Insights query results.
-func parseMaxMemMB(results [][]cwlogstypes.ResultField) int32 {
-	for _, row := range results {
-		for _, field := range row {
-			if aws.ToString(field.Field) == "maxMemMB" {
-				val, err := strconv.ParseFloat(aws.ToString(field.Value), 64)
-				if err != nil {
-					return 0
-				}
+// parseMaxMemMBByGroup extracts per-log-group maxMemMB values from CW Logs Insights results. The
+// @log field is returned as "accountId:logGroupName"; this strips the account prefix.
+func parseMaxMemMBByGroup(results [][]cwlogstypes.ResultField) map[string]int32 {
+	out := make(map[string]int32, len(results))
 
-				return int32(math.Ceil(val))
+	for _, row := range results {
+		var (
+			logGroup string
+			maxMemMB int32
+			hasValue bool
+		)
+
+		for _, field := range row {
+			switch aws.ToString(field.Field) {
+			case "@log":
+				logValue := aws.ToString(field.Value)
+				if idx := strings.Index(logValue, ":"); idx >= 0 {
+					logGroup = logValue[idx+1:]
+				} else {
+					logGroup = logValue
+				}
+			case "maxMemMB":
+				val, err := strconv.ParseFloat(aws.ToString(field.Value), 64)
+				if err == nil {
+					maxMemMB = int32(math.Ceil(val))
+					hasValue = true
+				}
 			}
+		}
+
+		if logGroup != "" && hasValue {
+			out[logGroup] = maxMemMB
 		}
 	}
 
-	return 0
+	return out
 }

--- a/service/cloudwatchlogs/service.go
+++ b/service/cloudwatchlogs/service.go
@@ -114,7 +114,7 @@ func (s *service) GetLambdaMaxMemoryUsedBatch(ctx context.Context, logGroupNames
 		}
 
 		if results.Status == cwlogstypes.QueryStatusFailed || results.Status == cwlogstypes.QueryStatusCancelled || results.Status == cwlogstypes.QueryStatusTimeout {
-			return nil, fmt.Errorf("query %s", results.Status)
+			return nil, fmt.Errorf("insights query failed with status: %s", results.Status)
 		}
 
 		time.Sleep(queryPollInterval)

--- a/service/cloudwatchlogs/service.go
+++ b/service/cloudwatchlogs/service.go
@@ -53,7 +53,7 @@ func (s *service) GetCloudWatchLogsWaste(ctx context.Context) ([]model.CloudWatc
 	return wasteLogGroups, nil
 }
 
-const queryPollInterval = 500 * time.Millisecond
+const queryPollInterval = 1 * time.Second
 
 // ListExistingLogGroups returns the set of log group names matching the given name prefix. This
 // is used to pre-filter before calling GetLambdaMaxMemoryUsedBatch, since a StartQuery fails the
@@ -117,7 +117,11 @@ func (s *service) GetLambdaMaxMemoryUsedBatch(ctx context.Context, logGroupNames
 			return nil, fmt.Errorf("insights query failed with status: %s", results.Status)
 		}
 
-		time.Sleep(queryPollInterval)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(queryPollInterval):
+		}
 	}
 }
 

--- a/service/cloudwatchlogs/service_test.go
+++ b/service/cloudwatchlogs/service_test.go
@@ -195,6 +195,129 @@ func TestGetLambdaMaxMemoryUsedBatch(t *testing.T) {
 	}
 }
 
+func TestGetLambdaMaxMemoryUsedBatch_IssuesGroupByLogQuery(t *testing.T) {
+	mockClient := new(awsinterfaces.MockCloudWatchLogsClient)
+
+	mockClient.On("StartQuery", mock.Anything, mock.MatchedBy(func(input *cloudwatchlogs.StartQueryInput) bool {
+		return input != nil && input.QueryString != nil &&
+			aws.ToString(input.QueryString) == `filter @type = "REPORT" | stats max(@maxMemoryUsed / 1048576) as maxMemMB by @log` &&
+			len(input.LogGroupNames) == 2
+	}), mock.Anything).Return(&cloudwatchlogs.StartQueryOutput{
+		QueryId: aws.String("query-assert"),
+	}, nil)
+
+	mockClient.On("GetQueryResults", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.GetQueryResultsOutput{
+		Status:  types.QueryStatusComplete,
+		Results: [][]types.ResultField{},
+	}, nil)
+
+	svc := &service{client: mockClient}
+	_, err := svc.GetLambdaMaxMemoryUsedBatch(context.Background(), []string{"/aws/lambda/a", "/aws/lambda/b"}, time.Now().AddDate(0, 0, -1), time.Now())
+
+	assert.NoError(t, err)
+	mockClient.AssertExpectations(t)
+}
+
+func TestParseMaxMemMBByGroup_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		results [][]types.ResultField
+		want    map[string]int32
+	}{
+		{
+			name: "strips accountId prefix from @log",
+			results: [][]types.ResultField{
+				{
+					{Field: aws.String("@log"), Value: aws.String("999999999999:/aws/lambda/fn")},
+					{Field: aws.String("maxMemMB"), Value: aws.String("10")},
+				},
+			},
+			want: map[string]int32{"/aws/lambda/fn": 10},
+		},
+		{
+			name: "handles @log without colon by using the raw value",
+			results: [][]types.ResultField{
+				{
+					{Field: aws.String("@log"), Value: aws.String("/aws/lambda/fn")},
+					{Field: aws.String("maxMemMB"), Value: aws.String("20")},
+				},
+			},
+			want: map[string]int32{"/aws/lambda/fn": 20},
+		},
+		{
+			name: "drops rows missing @log",
+			results: [][]types.ResultField{
+				{
+					{Field: aws.String("maxMemMB"), Value: aws.String("30")},
+				},
+			},
+			want: map[string]int32{},
+		},
+		{
+			name: "drops rows missing maxMemMB",
+			results: [][]types.ResultField{
+				{
+					{Field: aws.String("@log"), Value: aws.String("1:/aws/lambda/fn")},
+				},
+			},
+			want: map[string]int32{},
+		},
+		{
+			name: "drops rows with unparseable maxMemMB",
+			results: [][]types.ResultField{
+				{
+					{Field: aws.String("@log"), Value: aws.String("1:/aws/lambda/fn")},
+					{Field: aws.String("maxMemMB"), Value: aws.String("not-a-number")},
+				},
+			},
+			want: map[string]int32{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseMaxMemMBByGroup(tt.results)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestListExistingLogGroups(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := new(awsinterfaces.MockCloudWatchLogsClient)
+
+	mockClient.On("DescribeLogGroups", mock.Anything, mock.MatchedBy(func(input *cloudwatchlogs.DescribeLogGroupsInput) bool {
+		return input != nil && aws.ToString(input.LogGroupNamePrefix) == "/aws/lambda/"
+	}), mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
+		LogGroups: []types.LogGroup{
+			{LogGroupName: aws.String("/aws/lambda/fn-a")},
+			{LogGroupName: aws.String("/aws/lambda/fn-b")},
+			{LogGroupName: nil},
+		},
+	}, nil)
+
+	svc := &service{client: mockClient}
+	got, err := svc.ListExistingLogGroups(ctx, "/aws/lambda/")
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]struct{}{
+		"/aws/lambda/fn-a": {},
+		"/aws/lambda/fn-b": {},
+	}, got)
+}
+
+func TestListExistingLogGroups_DescribeError(t *testing.T) {
+	mockClient := new(awsinterfaces.MockCloudWatchLogsClient)
+	mockClient.On("DescribeLogGroups", mock.Anything, mock.Anything, mock.Anything).Return((*cloudwatchlogs.DescribeLogGroupsOutput)(nil), errors.New("throttled"))
+
+	svc := &service{client: mockClient}
+	_, err := svc.ListExistingLogGroups(context.Background(), "/aws/lambda/")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to describe log groups")
+}
+
 func TestNewService(t *testing.T) {
 	cfg := aws.Config{}
 	svc := NewService(cfg)

--- a/service/cloudwatchlogs/service_test.go
+++ b/service/cloudwatchlogs/service_test.go
@@ -83,7 +83,6 @@ func TestGetCloudWatchLogsWaste(t *testing.T) {
 
 				if tt.wantCount > 0 {
 					assert.Equal(t, "waste-group", waste[0].LogGroupName)
-					// 1024 bytes / (1024^3) * 0.03 = small value
 					assert.Greater(t, waste[0].EstimatedMonthlyCost, 0.0)
 				}
 			}
@@ -91,19 +90,21 @@ func TestGetCloudWatchLogsWaste(t *testing.T) {
 	}
 }
 
-func TestGetLambdaMaxMemoryUsed(t *testing.T) {
+func TestGetLambdaMaxMemoryUsedBatch(t *testing.T) {
 	ctx := context.Background()
 	startTime := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	endTime := time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC)
 
 	tests := []struct {
 		name       string
+		logGroups  []string
 		setupMocks func(*awsinterfaces.MockCloudWatchLogsClient)
-		wantMB     int32
+		want       map[string]int32
 		wantErr    bool
 	}{
 		{
-			name: "successful query returns max memory",
+			name:      "successful query returns max memory per log group",
+			logGroups: []string{"/aws/lambda/fn-a", "/aws/lambda/fn-b"},
 			setupMocks: func(m *awsinterfaces.MockCloudWatchLogsClient) {
 				m.On("StartQuery", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.StartQueryOutput{
 					QueryId: aws.String("query-123"),
@@ -112,24 +113,42 @@ func TestGetLambdaMaxMemoryUsed(t *testing.T) {
 					Status: types.QueryStatusComplete,
 					Results: [][]types.ResultField{
 						{
+							{Field: aws.String("@log"), Value: aws.String("123456789012:/aws/lambda/fn-a")},
 							{Field: aws.String("maxMemMB"), Value: aws.String("75.5")},
+						},
+						{
+							{Field: aws.String("@log"), Value: aws.String("123456789012:/aws/lambda/fn-b")},
+							{Field: aws.String("maxMemMB"), Value: aws.String("200")},
 						},
 					},
 				}, nil)
 			},
-			wantMB:  76, // ceil(75.5)
+			want: map[string]int32{
+				"/aws/lambda/fn-a": 76,
+				"/aws/lambda/fn-b": 200,
+			},
 			wantErr: false,
 		},
 		{
-			name: "start query fails",
+			name:      "empty log groups returns empty map without calling AWS",
+			logGroups: []string{},
+			setupMocks: func(_ *awsinterfaces.MockCloudWatchLogsClient) {
+			},
+			want:    map[string]int32{},
+			wantErr: false,
+		},
+		{
+			name:      "start query fails",
+			logGroups: []string{"/aws/lambda/fn-a"},
 			setupMocks: func(m *awsinterfaces.MockCloudWatchLogsClient) {
 				m.On("StartQuery", mock.Anything, mock.Anything, mock.Anything).Return((*cloudwatchlogs.StartQueryOutput)(nil), errors.New("access denied"))
 			},
-			wantMB:  0,
+			want:    nil,
 			wantErr: true,
 		},
 		{
-			name: "query fails status",
+			name:      "query fails status",
+			logGroups: []string{"/aws/lambda/fn-a"},
 			setupMocks: func(m *awsinterfaces.MockCloudWatchLogsClient) {
 				m.On("StartQuery", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.StartQueryOutput{
 					QueryId: aws.String("query-456"),
@@ -138,11 +157,12 @@ func TestGetLambdaMaxMemoryUsed(t *testing.T) {
 					Status: types.QueryStatusFailed,
 				}, nil)
 			},
-			wantMB:  0,
+			want:    nil,
 			wantErr: true,
 		},
 		{
-			name: "empty results returns zero",
+			name:      "empty results returns empty map",
+			logGroups: []string{"/aws/lambda/fn-a"},
 			setupMocks: func(m *awsinterfaces.MockCloudWatchLogsClient) {
 				m.On("StartQuery", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.StartQueryOutput{
 					QueryId: aws.String("query-789"),
@@ -152,7 +172,7 @@ func TestGetLambdaMaxMemoryUsed(t *testing.T) {
 					Results: [][]types.ResultField{},
 				}, nil)
 			},
-			wantMB:  0,
+			want:    map[string]int32{},
 			wantErr: false,
 		},
 	}
@@ -163,13 +183,13 @@ func TestGetLambdaMaxMemoryUsed(t *testing.T) {
 			tt.setupMocks(mockClient)
 
 			svc := &service{client: mockClient}
-			mem, err := svc.GetLambdaMaxMemoryUsed(ctx, "/aws/lambda/test-fn", startTime, endTime)
+			got, err := svc.GetLambdaMaxMemoryUsedBatch(ctx, tt.logGroups, startTime, endTime)
 
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.wantMB, mem)
+				assert.Equal(t, tt.want, got)
 			}
 		})
 	}

--- a/service/cloudwatchlogs/types.go
+++ b/service/cloudwatchlogs/types.go
@@ -18,7 +18,8 @@ type ClientAPI interface {
 // Service is the interface for AWS CloudWatch Logs service.
 type Service interface {
 	GetCloudWatchLogsWaste(ctx context.Context) ([]model.CloudWatchLogsWasteInfo, error)
-	GetLambdaMaxMemoryUsed(ctx context.Context, logGroupName string, startTime, endTime time.Time) (int32, error)
+	GetLambdaMaxMemoryUsedBatch(ctx context.Context, logGroupNames []string, startTime, endTime time.Time) (map[string]int32, error)
+	ListExistingLogGroups(ctx context.Context, prefix string) (map[string]struct{}, error)
 }
 
 type service struct {

--- a/service/lambda/service.go
+++ b/service/lambda/service.go
@@ -96,7 +96,7 @@ func (s *service) queryMaxMemoryInBatches(ctx context.Context, logGroupNames []s
 		g.Go(func() error {
 			results, err := s.logsService.GetLambdaMaxMemoryUsedBatch(ctx, batch, startTime, endTime)
 			if err != nil {
-				return nil
+				return fmt.Errorf("batch Insights query failed for %d log groups: %w", len(batch), err)
 			}
 
 			mu.Lock()
@@ -116,8 +116,9 @@ func (s *service) queryMaxMemoryInBatches(ctx context.Context, logGroupNames []s
 	return merged, nil
 }
 
-// buildOverProvisionedResults filters functions whose memory utilization falls below the
-// threshold and returns the corresponding recommendations.
+// buildOverProvisionedResults returns recommendations for functions whose observed max memory
+// falls below memoryThresholdPercent of configured memory. Recommendation is max(observed * 2,
+// minRecommendedMemoryMB) to leave headroom while respecting Lambda's 128 MB floor.
 func buildOverProvisionedResults(
 	logGroupToFunction map[string]lambdatypes.FunctionConfiguration,
 	maxMemByLogGroup map[string]int32,

--- a/service/lambda/service.go
+++ b/service/lambda/service.go
@@ -4,7 +4,8 @@ package lambda
 import (
 	"context"
 	"fmt"
-	"sync"
+	"maps"
+	"slices"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -47,26 +48,22 @@ func (s *service) GetOverProvisionedFunctions(ctx context.Context, memoryThresho
 	}
 
 	logGroupToFunction := make(map[string]lambdatypes.FunctionConfiguration, len(functions))
-	logGroupNames := make([]string, 0, len(functions))
 
 	for _, fn := range functions {
 		logGroupName := lambdaLogGroupPrefix + aws.ToString(fn.FunctionName)
-		if _, ok := existingLogGroups[logGroupName]; !ok {
-			continue
+		if _, ok := existingLogGroups[logGroupName]; ok {
+			logGroupToFunction[logGroupName] = fn
 		}
-
-		logGroupToFunction[logGroupName] = fn
-		logGroupNames = append(logGroupNames, logGroupName)
 	}
 
-	if len(logGroupNames) == 0 {
+	if len(logGroupToFunction) == 0 {
 		return nil, nil
 	}
 
 	now := time.Now()
 	startTime := now.AddDate(0, 0, -lookbackDays)
 
-	maxMemByLogGroup, err := s.queryMaxMemoryInBatches(ctx, logGroupNames, startTime, now)
+	maxMemByLogGroup, err := s.queryMaxMemoryInBatches(ctx, slices.Collect(maps.Keys(logGroupToFunction)), startTime, now)
 	if err != nil {
 		return nil, err
 	}
@@ -74,36 +71,30 @@ func (s *service) GetOverProvisionedFunctions(ctx context.Context, memoryThresho
 	return buildOverProvisionedResults(logGroupToFunction, maxMemByLogGroup, memoryThresholdPercent), nil
 }
 
+// batchResult carries the per-log-group max memory map from a single Insights query.
+type batchResult struct {
+	memByLogGroup map[string]int32
+}
+
 // queryMaxMemoryInBatches runs batched CloudWatch Logs Insights queries (up to
 // logGroupsPerInsightsQuery per query) concurrently and merges the per-log-group results.
 func (s *service) queryMaxMemoryInBatches(ctx context.Context, logGroupNames []string, startTime, endTime time.Time) (map[string]int32, error) {
-	var (
-		mu     sync.Mutex
-		merged = make(map[string]int32, len(logGroupNames))
-	)
+	batchCount := (len(logGroupNames) + logGroupsPerInsightsQuery - 1) / logGroupsPerInsightsQuery
+	results := make(chan batchResult, batchCount)
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(maxLogsConcurrency)
 
 	for start := 0; start < len(logGroupNames); start += logGroupsPerInsightsQuery {
-		end := start + logGroupsPerInsightsQuery
-		if end > len(logGroupNames) {
-			end = len(logGroupNames)
-		}
-
-		batch := logGroupNames[start:end]
+		batch := logGroupNames[start:min(start+logGroupsPerInsightsQuery, len(logGroupNames))]
 
 		g.Go(func() error {
-			results, err := s.logsService.GetLambdaMaxMemoryUsedBatch(ctx, batch, startTime, endTime)
+			r, err := s.logsService.GetLambdaMaxMemoryUsedBatch(ctx, batch, startTime, endTime)
 			if err != nil {
 				return fmt.Errorf("batch Insights query failed for %d log groups: %w", len(batch), err)
 			}
 
-			mu.Lock()
-			for k, v := range results {
-				merged[k] = v
-			}
-			mu.Unlock()
+			results <- batchResult{memByLogGroup: r}
 
 			return nil
 		})
@@ -111,6 +102,14 @@ func (s *service) queryMaxMemoryInBatches(ctx context.Context, logGroupNames []s
 
 	if err := g.Wait(); err != nil {
 		return nil, err
+	}
+
+	close(results)
+
+	merged := make(map[string]int32, len(logGroupNames))
+
+	for r := range results {
+		maps.Copy(merged, r.memByLogGroup)
 	}
 
 	return merged, nil

--- a/service/lambda/service.go
+++ b/service/lambda/service.go
@@ -16,8 +16,11 @@ import (
 )
 
 const (
-	lookbackDays       = 14
-	maxLogsConcurrency = 10
+	lookbackDays              = 14
+	maxLogsConcurrency        = 10
+	logGroupsPerInsightsQuery = 50
+	minRecommendedMemoryMB    = 128
+	lambdaLogGroupPrefix      = "/aws/lambda/"
 )
 
 // NewService creates a new Lambda service.
@@ -34,50 +37,73 @@ func (s *service) GetOverProvisionedFunctions(ctx context.Context, memoryThresho
 		return nil, fmt.Errorf("failed to list Lambda functions: %w", err)
 	}
 
+	if len(functions) == 0 {
+		return nil, nil
+	}
+
+	existingLogGroups, err := s.logsService.ListExistingLogGroups(ctx, lambdaLogGroupPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Lambda log groups: %w", err)
+	}
+
+	logGroupToFunction := make(map[string]lambdatypes.FunctionConfiguration, len(functions))
+	logGroupNames := make([]string, 0, len(functions))
+
+	for _, fn := range functions {
+		logGroupName := lambdaLogGroupPrefix + aws.ToString(fn.FunctionName)
+		if _, ok := existingLogGroups[logGroupName]; !ok {
+			continue
+		}
+
+		logGroupToFunction[logGroupName] = fn
+		logGroupNames = append(logGroupNames, logGroupName)
+	}
+
+	if len(logGroupNames) == 0 {
+		return nil, nil
+	}
+
 	now := time.Now()
 	startTime := now.AddDate(0, 0, -lookbackDays)
 
+	maxMemByLogGroup, err := s.queryMaxMemoryInBatches(ctx, logGroupNames, startTime, now)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildOverProvisionedResults(logGroupToFunction, maxMemByLogGroup, memoryThresholdPercent), nil
+}
+
+// queryMaxMemoryInBatches runs batched CloudWatch Logs Insights queries (up to
+// logGroupsPerInsightsQuery per query) concurrently and merges the per-log-group results.
+func (s *service) queryMaxMemoryInBatches(ctx context.Context, logGroupNames []string, startTime, endTime time.Time) (map[string]int32, error) {
 	var (
 		mu     sync.Mutex
-		result []model.LambdaOverProvisionedInfo
+		merged = make(map[string]int32, len(logGroupNames))
 	)
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(maxLogsConcurrency)
 
-	for _, fn := range functions {
-		fn := fn
+	for start := 0; start < len(logGroupNames); start += logGroupsPerInsightsQuery {
+		end := start + logGroupsPerInsightsQuery
+		if end > len(logGroupNames) {
+			end = len(logGroupNames)
+		}
+
+		batch := logGroupNames[start:end]
 
 		g.Go(func() error {
-			functionName := aws.ToString(fn.FunctionName)
-			configuredMemoryMB := aws.ToInt32(fn.MemorySize)
-			logGroupName := fmt.Sprintf("/aws/lambda/%s", functionName)
-
-			maxMemUsed, err := s.logsService.GetLambdaMaxMemoryUsed(ctx, logGroupName, startTime, now)
-			if err != nil || maxMemUsed <= 0 || configuredMemoryMB <= 0 {
+			results, err := s.logsService.GetLambdaMaxMemoryUsedBatch(ctx, batch, startTime, endTime)
+			if err != nil {
 				return nil
 			}
 
-			utilizationPercent := (float64(maxMemUsed) / float64(configuredMemoryMB)) * 100
-
-			if utilizationPercent < float64(memoryThresholdPercent) {
-				recommendedMB := maxMemUsed * 2
-				if recommendedMB < 128 {
-					recommendedMB = 128
-				}
-
-				mu.Lock()
-
-				result = append(result, model.LambdaOverProvisionedInfo{
-					FunctionName:        functionName,
-					Runtime:             string(fn.Runtime),
-					ConfiguredMemoryMB:  configuredMemoryMB,
-					MaxMemoryUsedMB:     maxMemUsed,
-					MemoryUtilization:   utilizationPercent,
-					RecommendedMemoryMB: recommendedMB,
-				})
-				mu.Unlock()
+			mu.Lock()
+			for k, v := range results {
+				merged[k] = v
 			}
+			mu.Unlock()
 
 			return nil
 		})
@@ -87,7 +113,50 @@ func (s *service) GetOverProvisionedFunctions(ctx context.Context, memoryThresho
 		return nil, err
 	}
 
-	return result, nil
+	return merged, nil
+}
+
+// buildOverProvisionedResults filters functions whose memory utilization falls below the
+// threshold and returns the corresponding recommendations.
+func buildOverProvisionedResults(
+	logGroupToFunction map[string]lambdatypes.FunctionConfiguration,
+	maxMemByLogGroup map[string]int32,
+	memoryThresholdPercent int,
+) []model.LambdaOverProvisionedInfo {
+	result := make([]model.LambdaOverProvisionedInfo, 0, len(maxMemByLogGroup))
+
+	for logGroup, maxMemUsed := range maxMemByLogGroup {
+		fn, ok := logGroupToFunction[logGroup]
+		if !ok {
+			continue
+		}
+
+		configuredMemoryMB := aws.ToInt32(fn.MemorySize)
+		if maxMemUsed <= 0 || configuredMemoryMB <= 0 {
+			continue
+		}
+
+		utilizationPercent := (float64(maxMemUsed) / float64(configuredMemoryMB)) * 100
+		if utilizationPercent >= float64(memoryThresholdPercent) {
+			continue
+		}
+
+		recommendedMB := maxMemUsed * 2
+		if recommendedMB < minRecommendedMemoryMB {
+			recommendedMB = minRecommendedMemoryMB
+		}
+
+		result = append(result, model.LambdaOverProvisionedInfo{
+			FunctionName:        aws.ToString(fn.FunctionName),
+			Runtime:             string(fn.Runtime),
+			ConfiguredMemoryMB:  configuredMemoryMB,
+			MaxMemoryUsedMB:     maxMemUsed,
+			MemoryUtilization:   utilizationPercent,
+			RecommendedMemoryMB: recommendedMB,
+		})
+	}
+
+	return result
 }
 
 func (s *service) listAllFunctions(ctx context.Context) ([]lambdatypes.FunctionConfiguration, error) {

--- a/service/lambda/service_test.go
+++ b/service/lambda/service_test.go
@@ -18,10 +18,20 @@ type mockCWLogsService struct {
 	mock.Mock
 }
 
-func (m *mockCWLogsService) GetLambdaMaxMemoryUsed(ctx context.Context, logGroupName string, startTime, endTime time.Time) (int32, error) {
-	args := m.Called(ctx, logGroupName, startTime, endTime)
+func (m *mockCWLogsService) GetLambdaMaxMemoryUsedBatch(ctx context.Context, logGroupNames []string, startTime, endTime time.Time) (map[string]int32, error) {
+	args := m.Called(ctx, logGroupNames, startTime, endTime)
 
-	return args.Get(0).(int32), args.Error(1)
+	res, _ := args.Get(0).(map[string]int32)
+
+	return res, args.Error(1)
+}
+
+func (m *mockCWLogsService) ListExistingLogGroups(ctx context.Context, prefix string) (map[string]struct{}, error) {
+	args := m.Called(ctx, prefix)
+
+	res, _ := args.Get(0).(map[string]struct{})
+
+	return res, args.Error(1)
 }
 
 func TestGetOverProvisionedFunctions(t *testing.T) {
@@ -33,7 +43,6 @@ func TestGetOverProvisionedFunctions(t *testing.T) {
 		logsService:  mockLogsService,
 	}
 
-	// Mock ListFunctions: one over-provisioned function, one normal function
 	mockLambdaClient.On("ListFunctions", mock.Anything, mock.Anything, mock.Anything).Return(&awslambda.ListFunctionsOutput{
 		Functions: []lambdatypes.FunctionConfiguration{
 			{
@@ -49,11 +58,15 @@ func TestGetOverProvisionedFunctions(t *testing.T) {
 		},
 	}, nil)
 
-	// Mock GetLambdaMaxMemoryUsed for over-provisioned function (uses 50 MB of 1024 MB = ~5%)
-	mockLogsService.On("GetLambdaMaxMemoryUsed", mock.Anything, "/aws/lambda/over-provisioned-fn", mock.Anything, mock.Anything).Return(int32(50), nil)
+	mockLogsService.On("ListExistingLogGroups", mock.Anything, "/aws/lambda/").Return(map[string]struct{}{
+		"/aws/lambda/over-provisioned-fn": {},
+		"/aws/lambda/normal-fn":           {},
+	}, nil)
 
-	// Mock GetLambdaMaxMemoryUsed for normal function (uses 200 MB of 256 MB = ~78%)
-	mockLogsService.On("GetLambdaMaxMemoryUsed", mock.Anything, "/aws/lambda/normal-fn", mock.Anything, mock.Anything).Return(int32(200), nil)
+	mockLogsService.On("GetLambdaMaxMemoryUsedBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(map[string]int32{
+		"/aws/lambda/over-provisioned-fn": 50,
+		"/aws/lambda/normal-fn":           200,
+	}, nil)
 
 	result, err := s.GetOverProvisionedFunctions(context.Background(), 10)
 
@@ -63,7 +76,7 @@ func TestGetOverProvisionedFunctions(t *testing.T) {
 	assert.Equal(t, int32(1024), result[0].ConfiguredMemoryMB)
 	assert.Equal(t, int32(50), result[0].MaxMemoryUsedMB)
 	assert.InDelta(t, 4.88, result[0].MemoryUtilization, 0.1)
-	assert.Equal(t, int32(128), result[0].RecommendedMemoryMB) // 50*2=100, but minimum is 128
+	assert.Equal(t, int32(128), result[0].RecommendedMemoryMB)
 	assert.Equal(t, "nodejs20.x", result[0].Runtime)
 
 	mockLambdaClient.AssertExpectations(t)
@@ -88,7 +101,7 @@ func TestGetOverProvisionedFunctions_ListFunctionsError(t *testing.T) {
 	mockLambdaClient.AssertExpectations(t)
 }
 
-func TestGetOverProvisionedFunctions_LogsError(t *testing.T) {
+func TestGetOverProvisionedFunctions_LogsBatchErrorIsSkipped(t *testing.T) {
 	mockLambdaClient := new(awsinterfaces.MockLambdaClient)
 	mockLogsService := new(mockCWLogsService)
 
@@ -107,8 +120,11 @@ func TestGetOverProvisionedFunctions_LogsError(t *testing.T) {
 		},
 	}, nil)
 
-	// Logs error should be skipped, not returned
-	mockLogsService.On("GetLambdaMaxMemoryUsed", mock.Anything, "/aws/lambda/fn-with-no-logs", mock.Anything, mock.Anything).Return(int32(0), errors.New("log group not found"))
+	mockLogsService.On("ListExistingLogGroups", mock.Anything, "/aws/lambda/").Return(map[string]struct{}{
+		"/aws/lambda/fn-with-no-logs": {},
+	}, nil)
+
+	mockLogsService.On("GetLambdaMaxMemoryUsedBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return((map[string]int32)(nil), errors.New("insights error"))
 
 	result, err := s.GetOverProvisionedFunctions(context.Background(), 10)
 

--- a/service/lambda/service_test.go
+++ b/service/lambda/service_test.go
@@ -3,6 +3,9 @@ package lambda
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,9 +19,16 @@ import (
 
 type mockCWLogsService struct {
 	mock.Mock
+	// GetLambdaMaxMemoryUsedBatchFn, when set, is called instead of the testify mock — useful
+	// when a test needs per-call dynamic returns (e.g., per-batch contents).
+	GetLambdaMaxMemoryUsedBatchFn func(ctx context.Context, logGroupNames []string, startTime, endTime time.Time) (map[string]int32, error)
 }
 
 func (m *mockCWLogsService) GetLambdaMaxMemoryUsedBatch(ctx context.Context, logGroupNames []string, startTime, endTime time.Time) (map[string]int32, error) {
+	if m.GetLambdaMaxMemoryUsedBatchFn != nil {
+		return m.GetLambdaMaxMemoryUsedBatchFn(ctx, logGroupNames, startTime, endTime)
+	}
+
 	args := m.Called(ctx, logGroupNames, startTime, endTime)
 
 	res, _ := args.Get(0).(map[string]int32)
@@ -101,7 +111,7 @@ func TestGetOverProvisionedFunctions_ListFunctionsError(t *testing.T) {
 	mockLambdaClient.AssertExpectations(t)
 }
 
-func TestGetOverProvisionedFunctions_LogsBatchErrorIsSkipped(t *testing.T) {
+func TestGetOverProvisionedFunctions_BatchErrorPropagates(t *testing.T) {
 	mockLambdaClient := new(awsinterfaces.MockLambdaClient)
 	mockLogsService := new(mockCWLogsService)
 
@@ -113,7 +123,7 @@ func TestGetOverProvisionedFunctions_LogsBatchErrorIsSkipped(t *testing.T) {
 	mockLambdaClient.On("ListFunctions", mock.Anything, mock.Anything, mock.Anything).Return(&awslambda.ListFunctionsOutput{
 		Functions: []lambdatypes.FunctionConfiguration{
 			{
-				FunctionName: aws.String("fn-with-no-logs"),
+				FunctionName: aws.String("fn-a"),
 				MemorySize:   aws.Int32(512),
 				Runtime:      lambdatypes.RuntimePython312,
 			},
@@ -121,17 +131,155 @@ func TestGetOverProvisionedFunctions_LogsBatchErrorIsSkipped(t *testing.T) {
 	}, nil)
 
 	mockLogsService.On("ListExistingLogGroups", mock.Anything, "/aws/lambda/").Return(map[string]struct{}{
-		"/aws/lambda/fn-with-no-logs": {},
+		"/aws/lambda/fn-a": {},
 	}, nil)
 
-	mockLogsService.On("GetLambdaMaxMemoryUsedBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return((map[string]int32)(nil), errors.New("insights error"))
+	mockLogsService.On("GetLambdaMaxMemoryUsedBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return((map[string]int32)(nil), errors.New("insights throttled"))
+
+	_, err := s.GetOverProvisionedFunctions(context.Background(), 10)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "insights throttled")
+	mockLambdaClient.AssertExpectations(t)
+	mockLogsService.AssertExpectations(t)
+}
+
+func TestGetOverProvisionedFunctions_ListLogGroupsErrorPropagates(t *testing.T) {
+	mockLambdaClient := new(awsinterfaces.MockLambdaClient)
+	mockLogsService := new(mockCWLogsService)
+
+	s := &service{
+		lambdaClient: mockLambdaClient,
+		logsService:  mockLogsService,
+	}
+
+	mockLambdaClient.On("ListFunctions", mock.Anything, mock.Anything, mock.Anything).Return(&awslambda.ListFunctionsOutput{
+		Functions: []lambdatypes.FunctionConfiguration{
+			{FunctionName: aws.String("fn-a"), MemorySize: aws.Int32(512)},
+		},
+	}, nil)
+
+	mockLogsService.On("ListExistingLogGroups", mock.Anything, "/aws/lambda/").Return((map[string]struct{})(nil), errors.New("access denied"))
+
+	_, err := s.GetOverProvisionedFunctions(context.Background(), 10)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list Lambda log groups")
+}
+
+func TestGetOverProvisionedFunctions_MissingLogGroupsAreSkipped(t *testing.T) {
+	mockLambdaClient := new(awsinterfaces.MockLambdaClient)
+	mockLogsService := new(mockCWLogsService)
+
+	s := &service{
+		lambdaClient: mockLambdaClient,
+		logsService:  mockLogsService,
+	}
+
+	mockLambdaClient.On("ListFunctions", mock.Anything, mock.Anything, mock.Anything).Return(&awslambda.ListFunctionsOutput{
+		Functions: []lambdatypes.FunctionConfiguration{
+			{FunctionName: aws.String("fn-present"), MemorySize: aws.Int32(1024), Runtime: lambdatypes.RuntimePython312},
+			{FunctionName: aws.String("fn-never-invoked"), MemorySize: aws.Int32(1024), Runtime: lambdatypes.RuntimePython312},
+		},
+	}, nil)
+
+	mockLogsService.On("ListExistingLogGroups", mock.Anything, "/aws/lambda/").Return(map[string]struct{}{
+		"/aws/lambda/fn-present": {},
+	}, nil)
+
+	capturedBatch := mock.MatchedBy(func(groups []string) bool {
+		return len(groups) == 1 && groups[0] == "/aws/lambda/fn-present"
+	})
+
+	mockLogsService.On("GetLambdaMaxMemoryUsedBatch", mock.Anything, capturedBatch, mock.Anything, mock.Anything).Return(map[string]int32{
+		"/aws/lambda/fn-present": 50,
+	}, nil)
+
+	result, err := s.GetOverProvisionedFunctions(context.Background(), 10)
+
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "fn-present", result[0].FunctionName)
+	mockLogsService.AssertExpectations(t)
+}
+
+func TestGetOverProvisionedFunctions_AllLogGroupsMissing(t *testing.T) {
+	mockLambdaClient := new(awsinterfaces.MockLambdaClient)
+	mockLogsService := new(mockCWLogsService)
+
+	s := &service{
+		lambdaClient: mockLambdaClient,
+		logsService:  mockLogsService,
+	}
+
+	mockLambdaClient.On("ListFunctions", mock.Anything, mock.Anything, mock.Anything).Return(&awslambda.ListFunctionsOutput{
+		Functions: []lambdatypes.FunctionConfiguration{
+			{FunctionName: aws.String("fn-a"), MemorySize: aws.Int32(512)},
+		},
+	}, nil)
+
+	mockLogsService.On("ListExistingLogGroups", mock.Anything, "/aws/lambda/").Return(map[string]struct{}{}, nil)
 
 	result, err := s.GetOverProvisionedFunctions(context.Background(), 10)
 
 	assert.NoError(t, err)
 	assert.Empty(t, result)
-	mockLambdaClient.AssertExpectations(t)
-	mockLogsService.AssertExpectations(t)
+	mockLogsService.AssertNotCalled(t, "GetLambdaMaxMemoryUsedBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGetOverProvisionedFunctions_ChunksAtFiftyAndMerges(t *testing.T) {
+	mockLambdaClient := new(awsinterfaces.MockLambdaClient)
+	mockLogsService := new(mockCWLogsService)
+
+	s := &service{
+		lambdaClient: mockLambdaClient,
+		logsService:  mockLogsService,
+	}
+
+	const totalFunctions = 101
+
+	functions := make([]lambdatypes.FunctionConfiguration, 0, totalFunctions)
+	existing := make(map[string]struct{}, totalFunctions)
+
+	for i := 0; i < totalFunctions; i++ {
+		name := fmt.Sprintf("fn-%03d", i)
+		functions = append(functions, lambdatypes.FunctionConfiguration{
+			FunctionName: aws.String(name),
+			MemorySize:   aws.Int32(1024),
+			Runtime:      lambdatypes.RuntimePython312,
+		})
+		existing["/aws/lambda/"+name] = struct{}{}
+	}
+
+	mockLambdaClient.On("ListFunctions", mock.Anything, mock.Anything, mock.Anything).Return(&awslambda.ListFunctionsOutput{Functions: functions}, nil)
+	mockLogsService.On("ListExistingLogGroups", mock.Anything, "/aws/lambda/").Return(existing, nil)
+
+	var (
+		mu         sync.Mutex
+		batchSizes []int
+	)
+
+	mockLogsService.GetLambdaMaxMemoryUsedBatchFn = func(_ context.Context, groups []string, _, _ time.Time) (map[string]int32, error) {
+		mu.Lock()
+
+		batchSizes = append(batchSizes, len(groups))
+		mu.Unlock()
+
+		out := make(map[string]int32, len(groups))
+		for _, g := range groups {
+			out[g] = 50
+		}
+
+		return out, nil
+	}
+
+	result, err := s.GetOverProvisionedFunctions(context.Background(), 10)
+
+	assert.NoError(t, err)
+	assert.Len(t, result, totalFunctions, "all functions across batches should be merged into the result")
+
+	sort.Ints(batchSizes)
+	assert.Equal(t, []int{1, 50, 50}, batchSizes, "expected batches of 50, 50, and 1")
 }
 
 func TestGetOverProvisionedFunctions_NoFunctions(t *testing.T) {

--- a/service/lambda/types.go
+++ b/service/lambda/types.go
@@ -15,7 +15,8 @@ type ClientAPI interface {
 
 // cloudWatchLogsService defines the interface for the CloudWatch Logs dependency.
 type cloudWatchLogsService interface {
-	GetLambdaMaxMemoryUsed(ctx context.Context, logGroupName string, startTime, endTime time.Time) (int32, error)
+	GetLambdaMaxMemoryUsedBatch(ctx context.Context, logGroupNames []string, startTime, endTime time.Time) (map[string]int32, error)
+	ListExistingLogGroups(ctx context.Context, prefix string) (map[string]struct{}, error)
 }
 
 type service struct {


### PR DESCRIPTION
## Summary

Closes #123.

Replaces the per-function CloudWatch Logs Insights query with batched queries that scan up to 50 log groups at once via `LogGroupNames`, grouped by `@log`. A prior `DescribeLogGroups` pass filters the function list down to log groups that actually exist, which avoids a single missing group failing an entire batch.

## Why

Each previous `GetLambdaMaxMemoryUsed` call issued its own `StartQuery` plus a polling loop, so N Lambda functions meant N round-trips. `StartQuery` supports up to 50 log groups per request, so batching collapses that to `ceil(N/50)` queries.

## Performance

Measured on an account with 312 Lambda functions (AWS_PROFILE=test), 2 runs each:

| Version  | Avg time |
|----------|----------|
| Baseline | ~56s     |
| Batched  | ~36s     |

~35% faster on this account; the delta should be larger on accounts where the per-query overhead dominates (e.g. the ~4 min runtime you mentioned).

## Implementation notes

- New `cloudwatchlogs.ListExistingLogGroups(prefix)` — used to pre-filter, needed because a missing log group fails the whole `StartQuery`.
- New `cloudwatchlogs.GetLambdaMaxMemoryUsedBatch(logGroupNames, ...)` replaces the single-group method. Query is `filter @type = "REPORT" | stats max(@maxMemoryUsed / 1048576) as maxMemMB by @log`. Parser strips the `accountId:` prefix from the `@log` field.
- `lambda` service describes `/aws/lambda/` log groups once, filters the function list to groups that exist, then runs batches of 50 concurrently (limit 10) via errgroup. Batch errors propagate — the pre-filter handles the benign "missing log group" case, so remaining errors (throttling, IAM, timeout) are systemic and worth surfacing rather than silently dropping up to 50 functions.

## Out of scope

Functions with Advanced Logging Controls (`LoggingConfig.LogGroup` pointing to a custom log group) remain invisible to this detector — same limitation as before this PR. Happy to open a follow-up issue if useful.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Run against a real account and verify results match the previous implementation
- [x] New unit tests cover: 101-function chunking + merge, pre-filter exclusion, all-log-groups-missing short-circuit, query string contains `by @log`, `@log` parsing edge cases, `ListExistingLogGroups` pagination + error