### PR TITLE
feat(pricing): fetch SageMaker hosting rates from AWS Pricing API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ aws-doctor is a Go CLI tool that provides AWS cost analysis and waste detection.
 - Cost comparison between current and previous month
 - 6-month trend analysis
 - Waste detection (unused EIPs, EBS volumes, stopped instances, load balancers, idle NAT Gateways, idle SageMaker real-time inference endpoints, etc.)
-- Region-aware cost estimates: `utils/pricing` fetches rates from the AWS Pricing API (always via the `us-east-1` endpoint, filtered by the caller's region) at startup and caches them in memory. The `Calculate*` helpers prefer the cached rate and fall back to the hardcoded us-east-1 defaults. New pricing categories should be added to `loader.go`'s category list and wired into the relevant `Calculate*` function, keeping the constant as a fallback.
+- Region-aware cost estimates: `service/pricing` fetches rates from the AWS Pricing API (always via the `us-east-1` endpoint, filtered by the caller's region) at startup and caches them in memory. The `Calculate*` helpers prefer the cached rate and fall back to the hardcoded us-east-1 defaults in `constants.go`. Categories currently fetched from the Pricing API: EBS volumes, EIP, NAT Gateway, ALB/NLB, CLB, CloudWatch Logs, RDS instances/storage/snapshots, and SageMaker hosting (real-time inference) instances. To add a new category, see the "Adding a Pricing Category" section in [CONTRIBUTING.md](CONTRIBUTING.md).
 - Startup banner uses ANSI truecolor; title color switches to AmazonOrange when a blue background is detected (Windows console attributes or `COLORFGBG` on Unix-like terminals), otherwise SkypeBlue. Override with `AWS_DOCTOR_BANNER_COLOR` (color name or ANSI code).
 
 ## Quick Reference

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,6 +173,18 @@ Use [Conventional Commits](https://www.conventionalcommits.org/) style:
 - **AWS clients** use the AWS SDK v2 patterns
 - **Concurrent operations** use `errgroup` for coordination
 
+### Adding a Pricing Category
+
+Cost estimates for waste detection live in `service/pricing`. Each category fetches its rate from the AWS Pricing API at startup (filtered to the caller's region) and falls back to a hardcoded us-east-1 constant when the API call fails or returns no match. To add a new category:
+
+1. **Add a category constant** to the `category*` block in `service/pricing/constants.go`, plus a default rate constant (e.g. `XxxCostPerMonth`) used as the fallback.
+2. **Add a `fetch(...)` call** inside `LoadRegionRates` in `service/pricing/service.go`. Provide the AWS `serviceCode`, the `productFamily` term match, any other filters needed to narrow to the specific SKU, and an `extract` function that returns the cache-key variant (or `""` for single-rate categories) from the SKU attributes. Verify the attribute names against an actual `aws pricing get-products --service-code <SERVICE>` response — the Pricing API uses different keys (`instanceType`, `instanceName`, `volumeApiName`, `usagetype`) across services.
+3. **Wire it into a `Calculate*` method** on `service` in `service/pricing/service.go`. Call `s.lookupMonthly(priceKey(category, variant), hoursPerMonth)` first when the Pricing API returns an hourly rate (e.g. compute instances, NAT, EIP), or `s.lookupMonthly(..., 0)` when it returns an already-monthly per-GB rate (e.g. EBS, CloudWatch Logs). Fall back to the hardcoded constant or table when the lookup misses. The cached value in `s.prices` is always stored as the raw `pricePerUnit` from the API, and `lookupMonthly`'s second argument is the multiplier applied on read.
+4. **Expose the method** on the `Service` interface in `service/pricing/types.go` if it is a new public method.
+5. **Add unit tests** in `service/pricing/service_test.go` covering both the cached path (use `s.setPrice(...)` to seed the cache) and the fallback path. Add a `TestLoadRegionRates_*` case using `mocks.MockPricingClient` with a representative price-list JSON document so the attribute names stay locked in.
+
+Keep the fallback table around — it is used both when the Pricing API is unreachable and when a specific SKU is missing from the response.
+
 ### Import Organization
 
 ```go

--- a/service/pricing/constants.go
+++ b/service/pricing/constants.go
@@ -19,15 +19,16 @@ const hoursPerMonth = 730.0
 // Cache keys are flat strings, usually "category" or "category:variant" (e.g. "nat",
 // "ebs:gp3", "rds-instance:db.t3.medium").
 const (
-	categoryEBS         = "ebs"
-	categoryEIP         = "eip"
-	categoryNAT         = "nat"
-	categoryLBApp       = "lb-app"
-	categoryLBClassic   = "lb-classic"
-	categoryCWLogs      = "cwlogs"
-	categoryRDSInstance = "rds-instance"
-	categoryRDSStorage  = "rds-storage"
-	categoryRDSSnapshot = "rds-snapshot"
+	categoryEBS              = "ebs"
+	categoryEIP              = "eip"
+	categoryNAT              = "nat"
+	categoryLBApp            = "lb-app"
+	categoryLBClassic        = "lb-classic"
+	categoryCWLogs           = "cwlogs"
+	categoryRDSInstance      = "rds-instance"
+	categoryRDSStorage       = "rds-storage"
+	categoryRDSSnapshot      = "rds-snapshot"
+	categorySageMakerHosting = "sagemaker-hosting"
 )
 
 const (

--- a/service/pricing/service.go
+++ b/service/pricing/service.go
@@ -168,6 +168,17 @@ func (s *service) LoadRegionRates(ctx context.Context) error {
 		return attrs["instanceType"], attrs["instanceType"] != ""
 	})
 
+	// SageMaker real-time inference (component=Hosting). The Pricing API exposes the instance
+	// type under the `instanceName` attribute (e.g. "ml.m5.xlarge"), which matches the value
+	// returned by DescribeEndpointConfig used by the orchestrator.
+	fetch(categorySageMakerHosting, "AmazonSageMaker", []pricingtypes.Filter{
+		regionFilter,
+		termMatch("productFamily", "ML Instance"),
+		termMatch("component", "Hosting"),
+	}, func(attrs map[string]string) (string, bool) {
+		return attrs["instanceName"], attrs["instanceName"] != ""
+	})
+
 	_ = g.Wait()
 
 	return errors.Join(fetchErr...)
@@ -263,10 +274,18 @@ func (s *service) CalculateSageMakerEndpointMonthlyCost(variants []model.SageMak
 	var total float64
 
 	for _, v := range variants {
-		total += sagemakerInstancePricing[v.InstanceType] * float64(v.InstanceCount)
+		total += s.sagemakerInstanceCost(v.InstanceType) * float64(v.InstanceCount)
 	}
 
 	return total
+}
+
+func (s *service) sagemakerInstanceCost(instanceType string) float64 {
+	if v, ok := s.lookupMonthly(priceKey(categorySageMakerHosting, instanceType), hoursPerMonth); ok {
+		return v
+	}
+
+	return sagemakerInstancePricing[instanceType]
 }
 
 // Internal helpers

--- a/service/pricing/service_test.go
+++ b/service/pricing/service_test.go
@@ -151,13 +151,71 @@ func TestCalculateRDSIdleInstanceMonthlyCost(t *testing.T) {
 }
 
 func TestCalculateSageMakerEndpointMonthlyCost(t *testing.T) {
-	s := &service{}
-	variants := []model.SageMakerVariant{
-		{InstanceType: "ml.t2.medium", InstanceCount: 2},
+	t.Run("fallback table", func(t *testing.T) {
+		s := &service{prices: make(map[string]float64)}
+		variants := []model.SageMakerVariant{
+			{InstanceType: "ml.t2.medium", InstanceCount: 2},
+		}
+		// 46.72 * 2 = 93.44
+		cost := s.CalculateSageMakerEndpointMonthlyCost(variants)
+		assert.Equal(t, 93.44, cost)
+	})
+
+	t.Run("cached value preferred over fallback", func(t *testing.T) {
+		s := &service{prices: make(map[string]float64)}
+		// hourly rate; lookupMonthly multiplies by hoursPerMonth (730)
+		s.setPrice(priceKey(categorySageMakerHosting, "ml.m5.xlarge"), 0.30)
+
+		variants := []model.SageMakerVariant{
+			{InstanceType: "ml.m5.xlarge", InstanceCount: 1},
+		}
+		assert.InDelta(t, 0.30*hoursPerMonth, s.CalculateSageMakerEndpointMonthlyCost(variants), 0.001)
+	})
+
+	t.Run("mixed cached and fallback variants", func(t *testing.T) {
+		s := &service{prices: make(map[string]float64)}
+		s.setPrice(priceKey(categorySageMakerHosting, "ml.m5.xlarge"), 0.30)
+
+		variants := []model.SageMakerVariant{
+			{InstanceType: "ml.m5.xlarge", InstanceCount: 1}, // cached: 0.30 * 730 = 219.0
+			{InstanceType: "ml.t2.medium", InstanceCount: 1}, // fallback: 46.72
+		}
+		assert.InDelta(t, 0.30*hoursPerMonth+46.72, s.CalculateSageMakerEndpointMonthlyCost(variants), 0.001)
+	})
+
+	t.Run("unknown instance type contributes zero", func(t *testing.T) {
+		s := &service{prices: make(map[string]float64)}
+		variants := []model.SageMakerVariant{
+			{InstanceType: "ml.does-not-exist.xlarge", InstanceCount: 4},
+		}
+		assert.Equal(t, 0.0, s.CalculateSageMakerEndpointMonthlyCost(variants))
+	})
+}
+
+func TestLoadRegionRates_SageMakerHosting(t *testing.T) {
+	ctx := context.Background()
+	mockClient := new(awsinterfaces.MockPricingClient)
+	s := &service{
+		client: mockClient,
+		prices: make(map[string]float64),
+		region: "us-east-1",
 	}
-	// 46.72 * 2 = 93.44
-	cost := s.CalculateSageMakerEndpointMonthlyCost(variants)
-	assert.Equal(t, 93.44, cost)
+
+	sagemakerJSON := `{
+		"product": { "attributes": { "instanceName": "ml.m5.xlarge", "component": "Hosting", "productFamily": "ML Instance" } },
+		"terms": { "OnDemand": { "SKU": { "priceDimensions": { "DIM": { "pricePerUnit": { "USD": "0.30" } } } } } }
+	}`
+
+	mockClient.On("GetProducts", mock.Anything, mock.Anything, mock.Anything).Return(&awspricing.GetProductsOutput{
+		PriceList: []string{sagemakerJSON},
+	}, nil)
+
+	err := s.LoadRegionRates(ctx)
+	assert.NoError(t, err)
+
+	price, ok := s.lookupMonthly(priceKey(categorySageMakerHosting, "ml.m5.xlarge"), 0)
+	assert.True(t, ok)
+	assert.Equal(t, 0.30, price)
 }
 
 func TestLoadRegionRates(t *testing.T) {


### PR DESCRIPTION
Closes #135.

## Summary

- Adds SageMaker real-time inference (hosting) instances to the AWS Pricing API loader (`AmazonSageMaker` / `productFamily=ML Instance` / `component=Hosting`, keyed on `instanceName`), so users outside `us-east-1` get region-accurate cost estimates instead of the static fallback table.
- `CalculateSageMakerEndpointMonthlyCost` now follows the same cache-first / hardcoded-fallback pattern used for EC2 and RDS. The `sagemakerInstancePricing` table is retained as the fallback when the Pricing API is unreachable or a specific instance type is missing from the response.
- Documents the integration pattern in `CONTRIBUTING.md` under "Adding a Pricing Category" and refreshes the stale `utils/pricing` reference in `AGENTS.md` (the package was moved to `service/pricing` in #133).

## Test Plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages green; `service/pricing` coverage 98.0%)
- [x] `golangci-lint run ./...` (0 issues)
- [x] New unit tests cover: cached-rate path, fallback-table path, mixed cached + fallback variants, unknown instance type → 0, and a `TestLoadRegionRates_SageMakerHosting` that locks in the SageMaker Pricing API JSON attribute names (`instanceName` / `component` / `productFamily`)