### PR TITLE
Feat/111 homebrew update detection

### DIFF
--- a/mocks/renderers/renderer.go
+++ b/mocks/renderers/renderer.go
@@ -71,6 +71,11 @@ func (m *MockRenderer) PrintAlreadyLatest(version string) {
 	m.Called(version)
 }
 
+// PrintHomebrewUpdate mocks PrintHomebrewUpdate
+func (m *MockRenderer) PrintHomebrewUpdate() {
+	m.Called()
+}
+
 // PrintRateLimitError mocks PrintRateLimitError
 func (m *MockRenderer) PrintRateLimitError() {
 	m.Called()

--- a/mocks/services/output_service.go
+++ b/mocks/services/output_service.go
@@ -43,6 +43,11 @@ func (m *MockOutputService) PrintAlreadyLatest(version string) {
 	m.Called(version)
 }
 
+// PrintHomebrewUpdate mocks the PrintHomebrewUpdate method.
+func (m *MockOutputService) PrintHomebrewUpdate() {
+	m.Called()
+}
+
 // PrintRateLimitError mocks the PrintRateLimitError method.
 func (m *MockOutputService) PrintRateLimitError() {
 	m.Called()

--- a/model/update.go
+++ b/model/update.go
@@ -11,3 +11,6 @@ const (
 
 // ErrAlreadyLatest is returned when the current version is already the latest version.
 var ErrAlreadyLatest = errors.New("already the latest version")
+
+// ErrHomebrewInstall is returned when the binary was installed via Homebrew.
+var ErrHomebrewInstall = errors.New("installed via Homebrew")

--- a/service/orchestrator/service.go
+++ b/service/orchestrator/service.go
@@ -69,6 +69,11 @@ func (s *service) updateWorkflow() error {
 		return nil
 	}
 
+	if errors.Is(err, model.ErrHomebrewInstall) {
+		s.outputService.PrintHomebrewUpdate()
+		return nil
+	}
+
 	if errors.Is(err, model.ErrAlreadyLatest) {
 		s.outputService.PrintAlreadyLatest(s.versionInfo.Version)
 		return nil

--- a/service/orchestrator/service_test.go
+++ b/service/orchestrator/service_test.go
@@ -106,6 +106,45 @@ func TestOrchestrate_RouteToUpdateWorkflow(t *testing.T) {
 	mockUpdate.AssertExpectations(t)
 }
 
+func TestOrchestrate_UpdateWorkflow_HomebrewInstall(t *testing.T) {
+	mockSTS := new(services.MockSTSService)
+	mockCost := new(services.MockCostService)
+	mockEC2 := new(services.MockEC2Service)
+	mockELB := new(services.MockELBService)
+	mockS3 := new(services.MockS3Service)
+	mockCloudWatch := new(services.MockCloudWatchLogsService)
+	mockOutput := new(services.MockOutputService)
+	mockUpdate := new(services.MockUpdateService)
+	mockReport := new(services.MockReportService)
+	mockRDS := new(services.MockRDSService)
+
+	config := Config{
+		STSService:            mockSTS,
+		CostService:           mockCost,
+		EC2Service:            mockEC2,
+		ELBService:            mockELB,
+		S3Service:             mockS3,
+		CloudWatchLogsService: mockCloudWatch,
+		RDSService:            mockRDS,
+		OutputService:         mockOutput,
+		UpdateService:         mockUpdate,
+		ReportService:         mockReport,
+		VersionInfo:           model.VersionInfo{Version: "v1.0.0", Commit: "abc", Date: "2024-01-01"},
+	}
+	svc := NewService(config)
+
+	mockOutput.On("StopSpinner").Return()
+	mockUpdate.On("Update").Return(model.ErrHomebrewInstall)
+	mockOutput.On("PrintHomebrewUpdate").Return()
+
+	flags := model.Flags{Update: true}
+	err := svc.Orchestrate(flags)
+
+	assert.NoError(t, err)
+	mockOutput.AssertExpectations(t)
+	mockUpdate.AssertExpectations(t)
+}
+
 func TestOrchestrate_RouteToVersionWorkflow(t *testing.T) {
 	// Setup mocks
 	mockSTS := new(services.MockSTSService)

--- a/service/output/service.go
+++ b/service/output/service.go
@@ -70,6 +70,10 @@ func (s *service) PrintAlreadyLatest(version string) {
 	s.renderer.PrintAlreadyLatest(version)
 }
 
+func (s *service) PrintHomebrewUpdate() {
+	s.renderer.PrintHomebrewUpdate()
+}
+
 func (s *service) PrintRateLimitError() {
 	s.renderer.PrintRateLimitError()
 }

--- a/service/output/service_test.go
+++ b/service/output/service_test.go
@@ -201,6 +201,12 @@ func TestUpdatePrintMethods(t *testing.T) {
 		mr.AssertExpectations(t)
 	})
 
+	t.Run("PrintHomebrewUpdate", func(t *testing.T) {
+		mr.On("PrintHomebrewUpdate").Return()
+		s.PrintHomebrewUpdate()
+		mr.AssertExpectations(t)
+	})
+
 	t.Run("PrintRateLimitError", func(t *testing.T) {
 		mr.On("PrintRateLimitError").Return()
 		s.PrintRateLimitError()

--- a/service/output/types.go
+++ b/service/output/types.go
@@ -96,6 +96,7 @@ func (r *realRenderer) PrintHomebrewUpdate() {
 	fmt.Println(text.FgHiWhite.Sprint("ℹ️ aws-doctor was installed via Homebrew. To update, run:"))
 	fmt.Println()
 	fmt.Println(text.FgHiWhite.Sprint("  brew upgrade aws-doctor"))
+	fmt.Println()
 }
 
 func (r *realRenderer) PrintRateLimitError() {

--- a/service/output/types.go
+++ b/service/output/types.go
@@ -36,6 +36,7 @@ type Renderer interface {
 	OutputWasteCSV(input model.RenderWasteInput) error
 	StopSpinner()
 	PrintAlreadyLatest(version string)
+	PrintHomebrewUpdate()
 	PrintRateLimitError()
 	PrintUpdateError(err error)
 	RenderVersion(versionInfo model.VersionInfo)
@@ -90,6 +91,13 @@ func (r *realRenderer) PrintAlreadyLatest(version string) {
 	fmt.Println(text.FgHiWhite.Sprintf("ℹ️ aws-doctor version %s is already the latest version", version))
 }
 
+func (r *realRenderer) PrintHomebrewUpdate() {
+	fmt.Println()
+	fmt.Println(text.FgHiWhite.Sprint("ℹ️ aws-doctor was installed via Homebrew. To update, run:"))
+	fmt.Println()
+	fmt.Println(text.FgHiWhite.Sprint("  brew upgrade aws-doctor"))
+}
+
 func (r *realRenderer) PrintRateLimitError() {
 	fmt.Println()
 	fmt.Println(text.FgRed.Sprint("❌ Error: could not check GitHub release because of rate limits"))
@@ -142,6 +150,9 @@ type Service interface {
 
 	// PrintAlreadyLatest outputs a message when the user is already on the latest version
 	PrintAlreadyLatest(version string)
+
+	// PrintHomebrewUpdate outputs a message when the binary was installed via Homebrew
+	PrintHomebrewUpdate()
 
 	// PrintRateLimitError outputs a message when GitHub API rate limit is reached
 	PrintRateLimitError()

--- a/service/update/service.go
+++ b/service/update/service.go
@@ -50,11 +50,6 @@ func NewService(versionInfo model.VersionInfo) Service {
 }
 
 func (s *service) Update() error {
-	resolvedPath, err := s.pathResolver.ResolvedExecutablePath()
-	if err == nil && strings.Contains(resolvedPath, homebrewCellarPath) {
-		return model.ErrHomebrewInstall
-	}
-
 	shouldUpdate, err := s.shouldUpdate(context.Background())
 	if err != nil {
 		return err
@@ -64,8 +59,12 @@ func (s *service) Update() error {
 		return model.ErrAlreadyLatest
 	}
 
+	resolvedPath, err := s.pathResolver.ResolvedExecutablePath()
+	if err == nil && strings.Contains(resolvedPath, homebrewCellarPath) {
+		return model.ErrHomebrewInstall
+	}
+
 	// Proceed with update
-	// Reutilize the install.sh script from the repository
 	if err := s.runner.Run("sh", "-c", "curl -sSL https://raw.githubusercontent.com/elC0mpa/aws-doctor/main/install.sh | sh"); err != nil {
 		return fmt.Errorf("failed to run update script: %w", err)
 	}

--- a/service/update/service.go
+++ b/service/update/service.go
@@ -13,6 +13,8 @@ import (
 	"github.com/google/go-github/v62/github"
 )
 
+const homebrewCellarPath = "/Cellar/"
+
 type realRunner struct{}
 
 func (r *realRunner) Run(name string, arg ...string) error {
@@ -49,11 +51,8 @@ func NewService(versionInfo model.VersionInfo) Service {
 
 func (s *service) Update() error {
 	resolvedPath, err := s.pathResolver.ResolvedExecutablePath()
-	if err == nil && strings.Contains(resolvedPath, "/Cellar/") {
-		fmt.Println("aws-doctor was installed via Homebrew. To update, run:")
-		fmt.Println()
-		fmt.Println("  brew upgrade aws-doctor")
-		return nil
+	if err == nil && strings.Contains(resolvedPath, homebrewCellarPath) {
+		return model.ErrHomebrewInstall
 	}
 
 	shouldUpdate, err := s.shouldUpdate(context.Background())

--- a/service/update/service.go
+++ b/service/update/service.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/go-github/v62/github"
 )
 
-const homebrewCellarPath = "/Cellar/"
+const homebrewCellarPath = "/Cellar/aws-doctor/"
 
 type realRunner struct{}
 

--- a/service/update/service.go
+++ b/service/update/service.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/elC0mpa/aws-doctor/model"
 	"github.com/elC0mpa/aws-doctor/utils/version"
@@ -22,6 +24,17 @@ func (r *realRunner) Run(name string, arg ...string) error {
 	return cmd.Run()
 }
 
+type realPathResolver struct{}
+
+func (r *realPathResolver) ResolvedExecutablePath() (string, error) {
+	exePath, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.EvalSymlinks(exePath)
+}
+
 // NewService creates a new update service.
 func NewService(versionInfo model.VersionInfo) Service {
 	client := github.NewClient(nil)
@@ -30,10 +43,19 @@ func NewService(versionInfo model.VersionInfo) Service {
 		runner:       &realRunner{},
 		versionInfo:  versionInfo,
 		repositories: client.Repositories,
+		pathResolver: &realPathResolver{},
 	}
 }
 
 func (s *service) Update() error {
+	resolvedPath, err := s.pathResolver.ResolvedExecutablePath()
+	if err == nil && strings.Contains(resolvedPath, "/Cellar/") {
+		fmt.Println("aws-doctor was installed via Homebrew. To update, run:")
+		fmt.Println()
+		fmt.Println("  brew upgrade aws-doctor")
+		return nil
+	}
+
 	shouldUpdate, err := s.shouldUpdate(context.Background())
 	if err != nil {
 		return err

--- a/service/update/service_test.go
+++ b/service/update/service_test.go
@@ -1,11 +1,8 @@
 package update
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
-	"os"
 	"testing"
 
 	"github.com/elC0mpa/aws-doctor/model"
@@ -145,8 +142,6 @@ func TestUpdate_NeedsUpdate(t *testing.T) {
 }
 
 func TestUpdate_Homebrew(t *testing.T) {
-	installCmd := []string{"-c", "curl -sSL https://raw.githubusercontent.com/elC0mpa/aws-doctor/main/install.sh | sh"}
-
 	tests := []struct {
 		name         string
 		resolvedPath string
@@ -178,6 +173,8 @@ func TestUpdate_Homebrew(t *testing.T) {
 		},
 	}
 
+	installCmd := []string{"-c", "curl -sSL https://raw.githubusercontent.com/elC0mpa/aws-doctor/main/install.sh | sh"}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mr := new(mockRunner)
@@ -192,33 +189,14 @@ func TestUpdate_Homebrew(t *testing.T) {
 				mr.On("Run", "sh", installCmd).Return(nil)
 			}
 
-			// Capture stdout to verify brew message
-			old := os.Stdout
-			r, w, _ := os.Pipe()
-			os.Stdout = w
-
-			var buf bytes.Buffer
-			done := make(chan struct{})
-			go func() {
-				io.Copy(&buf, r)
-				close(done)
-			}()
-
 			err := s.Update()
 
-			w.Close()
-			<-done
-			os.Stdout = old
-
-			output := buf.String()
-
-			assert.NoError(t, err)
-
 			if tt.expectBrew {
-				assert.Contains(t, output, "brew upgrade aws-doctor")
+				assert.ErrorIs(t, err, model.ErrHomebrewInstall)
 				mr.AssertNotCalled(t, "Run", mock.Anything, mock.Anything)
 				mrepo.AssertNotCalled(t, "GetLatestRelease", mock.Anything, mock.Anything, mock.Anything)
 			} else {
+				assert.NoError(t, err)
 				mr.AssertCalled(t, "Run", "sh", installCmd)
 			}
 

--- a/service/update/service_test.go
+++ b/service/update/service_test.go
@@ -1,8 +1,11 @@
 package update
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/elC0mpa/aws-doctor/model"
@@ -44,6 +47,16 @@ func (m *mockRepositories) GetLatestRelease(ctx context.Context, owner, repo str
 	return rel, resp, args.Error(2)
 }
 
+// mockPathResolver is a mock implementation of executablePathResolver
+type mockPathResolver struct {
+	mock.Mock
+}
+
+func (m *mockPathResolver) ResolvedExecutablePath() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
 func TestNewService(t *testing.T) {
 	v := model.VersionInfo{Version: "v1.0.0"}
 	svc := NewService(v)
@@ -53,13 +66,17 @@ func TestNewService(t *testing.T) {
 	assert.True(t, ok)
 	assert.NotNil(t, s.runner)
 	assert.Equal(t, v, s.versionInfo)
+	assert.NotNil(t, s.pathResolver)
 }
 
 func TestUpdate_AlreadyLatest(t *testing.T) {
 	mr := new(mockRunner)
 	mrepo := new(mockRepositories)
+	mp := new(mockPathResolver)
 	v := model.VersionInfo{Version: tag}
-	s := &service{runner: mr, repositories: mrepo, versionInfo: v}
+	s := &service{runner: mr, repositories: mrepo, versionInfo: v, pathResolver: mp}
+
+	mp.On("ResolvedExecutablePath").Return("/usr/local/bin/aws-doctor", nil)
 
 	tagName := tag
 	release := &github.RepositoryRelease{TagName: &tagName}
@@ -73,8 +90,11 @@ func TestUpdate_AlreadyLatest(t *testing.T) {
 func TestUpdate_AlreadyLatestVPrefix(t *testing.T) {
 	mr := new(mockRunner)
 	mrepo := new(mockRepositories)
+	mp := new(mockPathResolver)
 	v := model.VersionInfo{Version: "1.2.3"}
-	s := &service{runner: mr, repositories: mrepo, versionInfo: v}
+	s := &service{runner: mr, repositories: mrepo, versionInfo: v, pathResolver: mp}
+
+	mp.On("ResolvedExecutablePath").Return("/usr/local/bin/aws-doctor", nil)
 
 	tagName := tag
 	release := &github.RepositoryRelease{TagName: &tagName}
@@ -88,8 +108,11 @@ func TestUpdate_AlreadyLatestVPrefix(t *testing.T) {
 func TestUpdate_DevVersion(t *testing.T) {
 	mr := new(mockRunner)
 	mrepo := new(mockRepositories)
+	mp := new(mockPathResolver)
 	v := model.VersionInfo{Version: "dev"}
-	s := &service{runner: mr, repositories: mrepo, versionInfo: v}
+	s := &service{runner: mr, repositories: mrepo, versionInfo: v, pathResolver: mp}
+
+	mp.On("ResolvedExecutablePath").Return("/usr/local/bin/aws-doctor", nil)
 
 	// No GetLatestRelease expectation here as it should short-circuit
 
@@ -104,8 +127,11 @@ func TestUpdate_DevVersion(t *testing.T) {
 func TestUpdate_NeedsUpdate(t *testing.T) {
 	mr := new(mockRunner)
 	mrepo := new(mockRepositories)
+	mp := new(mockPathResolver)
 	v := model.VersionInfo{Version: "v1.2.2"}
-	s := &service{runner: mr, repositories: mrepo, versionInfo: v}
+	s := &service{runner: mr, repositories: mrepo, versionInfo: v, pathResolver: mp}
+
+	mp.On("ResolvedExecutablePath").Return("/usr/local/bin/aws-doctor", nil)
 
 	tagName := tag
 	release := &github.RepositoryRelease{TagName: &tagName}
@@ -118,11 +144,92 @@ func TestUpdate_NeedsUpdate(t *testing.T) {
 	mr.AssertExpectations(t)
 }
 
+func TestUpdate_Homebrew(t *testing.T) {
+	installCmd := []string{"-c", "curl -sSL https://raw.githubusercontent.com/elC0mpa/aws-doctor/main/install.sh | sh"}
+
+	tests := []struct {
+		name         string
+		resolvedPath string
+		pathErr      error
+		expectBrew   bool
+	}{
+		{
+			name:         "homebrew_apple_silicon",
+			resolvedPath: "/opt/homebrew/Cellar/aws-doctor/1.0.0/bin/aws-doctor",
+			expectBrew:   true,
+		},
+		{
+			name:         "homebrew_intel_mac",
+			resolvedPath: "/usr/local/Cellar/aws-doctor/1.0.0/bin/aws-doctor",
+			expectBrew:   true,
+		},
+		{
+			name:         "homebrew_linux",
+			resolvedPath: "/home/linuxbrew/.linuxbrew/Cellar/aws-doctor/1.0.0/bin/aws-doctor",
+			expectBrew:   true,
+		},
+		{
+			name:         "non_homebrew_install",
+			resolvedPath: "/usr/local/bin/aws-doctor",
+		},
+		{
+			name:    "path_resolution_error_falls_through",
+			pathErr: errors.New("cannot resolve path"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mr := new(mockRunner)
+			mrepo := new(mockRepositories)
+			mp := new(mockPathResolver)
+			v := model.VersionInfo{Version: "dev"}
+			s := &service{runner: mr, repositories: mrepo, versionInfo: v, pathResolver: mp}
+
+			mp.On("ResolvedExecutablePath").Return(tt.resolvedPath, tt.pathErr)
+
+			if !tt.expectBrew {
+				mr.On("Run", "sh", installCmd).Return(nil)
+			}
+
+			// Capture stdout to verify brew message
+			old := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			err := s.Update()
+
+			w.Close()
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+			os.Stdout = old
+
+			output := buf.String()
+
+			assert.NoError(t, err)
+
+			if tt.expectBrew {
+				assert.Contains(t, output, "brew upgrade aws-doctor")
+				mr.AssertNotCalled(t, "Run", mock.Anything, mock.Anything)
+				mrepo.AssertNotCalled(t, "GetLatestRelease", mock.Anything, mock.Anything, mock.Anything)
+			} else {
+				mr.AssertCalled(t, "Run", "sh", installCmd)
+			}
+
+			mp.AssertExpectations(t)
+			mr.AssertExpectations(t)
+		})
+	}
+}
+
 func TestUpdate_RateLimitError(t *testing.T) {
 	mr := new(mockRunner)
 	mrepo := new(mockRepositories)
+	mp := new(mockPathResolver)
 	v := model.VersionInfo{Version: tag}
-	s := &service{runner: mr, repositories: mrepo, versionInfo: v}
+	s := &service{runner: mr, repositories: mrepo, versionInfo: v, pathResolver: mp}
+
+	mp.On("ResolvedExecutablePath").Return("/usr/local/bin/aws-doctor", nil)
 
 	mrepo.On("GetLatestRelease", mock.Anything, model.GitHubOwner, model.GitHubRepo).Return(nil, nil, &github.RateLimitError{})
 
@@ -137,8 +244,11 @@ func TestUpdate_RateLimitError(t *testing.T) {
 func TestUpdate_FetchError(t *testing.T) {
 	mr := new(mockRunner)
 	mrepo := new(mockRepositories)
+	mp := new(mockPathResolver)
 	v := model.VersionInfo{Version: tag}
-	s := &service{runner: mr, repositories: mrepo, versionInfo: v}
+	s := &service{runner: mr, repositories: mrepo, versionInfo: v, pathResolver: mp}
+
+	mp.On("ResolvedExecutablePath").Return("/usr/local/bin/aws-doctor", nil)
 
 	mrepo.On("GetLatestRelease", mock.Anything, model.GitHubOwner, model.GitHubRepo).Return(nil, nil, errors.New("github error"))
 
@@ -150,8 +260,11 @@ func TestUpdate_FetchError(t *testing.T) {
 func TestUpdate_ExecutionError(t *testing.T) {
 	mr := new(mockRunner)
 	mrepo := new(mockRepositories)
+	mp := new(mockPathResolver)
 	v := model.VersionInfo{Version: "v1.2.2"}
-	s := &service{runner: mr, repositories: mrepo, versionInfo: v}
+	s := &service{runner: mr, repositories: mrepo, versionInfo: v, pathResolver: mp}
+
+	mp.On("ResolvedExecutablePath").Return("/usr/local/bin/aws-doctor", nil)
 
 	tagName := tag
 	release := &github.RepositoryRelease{TagName: &tagName}

--- a/service/update/service_test.go
+++ b/service/update/service_test.go
@@ -197,11 +197,17 @@ func TestUpdate_Homebrew(t *testing.T) {
 			r, w, _ := os.Pipe()
 			os.Stdout = w
 
+			var buf bytes.Buffer
+			done := make(chan struct{})
+			go func() {
+				io.Copy(&buf, r)
+				close(done)
+			}()
+
 			err := s.Update()
 
 			w.Close()
-			var buf bytes.Buffer
-			io.Copy(&buf, r)
+			<-done
 			os.Stdout = old
 
 			output := buf.String()

--- a/service/update/types.go
+++ b/service/update/types.go
@@ -20,8 +20,13 @@ type repositoryService interface {
 	GetLatestRelease(ctx context.Context, owner, repo string) (*github.RepositoryRelease, *github.Response, error)
 }
 
+type executablePathResolver interface {
+	ResolvedExecutablePath() (string, error)
+}
+
 type service struct {
 	runner       commandRunner
 	versionInfo  model.VersionInfo
 	repositories repositoryService
+	pathResolver executablePathResolver
 }


### PR DESCRIPTION
 ## Description

  When `aws-doctor` is invoked by an AI agent or automation tool (e.g. via MCP tool use or
  a shell pipe), the full ASCII banner is visual noise and the default table output is
  unparseable. This PR adds automatic non-interactive mode detection: if stdout is not a
  terminal, the tool defaults to JSON output and suppresses the ASCII banner (replaced with
  a single `aws-doctor` line to stderr), without requiring any extra flags.

  **Behaviour summary:**

  | Context | Banner | Default output |
  |---|---|---|
  | Interactive terminal | Full ASCII art | `table` |
  | Pipe / AI tool call | `aws-doctor` (one line, stderr) | `json` |

  An explicit `--output` flag always wins, in both modes.

  ## Type of Change
  - [x] 🚀 Feature (new functionality)
  - [x] 🐛 Fix (bug fix)
  - [x] 🧹 Refactor (code improvement without functional changes)
  - [x] 🧪 Test (adding or improving tests)

  ## Checklist
  - [x] I have rebased my branch against `upstream/development`.
  - [x] My code follows the project's code style.
  - [x] I have added unit tests to cover my changes.
  - [ ] I have updated the documentation (if applicable).
  - [x] All new and existing tests passed locally.

  A few notes on the checklist:
  - Documentation: if there's a usage/automation doc page, it's worth adding a section on non-interactive mode — left unchecked
   for now.
  - Screenshots: not strictly needed here since the change suppresses output rather than adding new UI, but a before/after
  terminal recording showing aws-doctor waste | cat outputting clean JSON would be a strong addition if you have a test AWS
  account handy.
