### PR TITLE
feat(cli): auto-detect non-interactive mode for AI/tool use

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -13,12 +13,13 @@ import (
 )
 
 const (
-	ec2     = "ec2"
-	s3Const = "s3"
-	dev     = "dev"
-	none    = "none"
-	unknown = "unknown"
-	table   = "table"
+	ec2        = "ec2"
+	s3Const    = "s3"
+	dev        = "dev"
+	none       = "none"
+	unknown    = "unknown"
+	table      = "table"
+	outputJSON = "json"
 )
 
 // MockOrchestrator is a mock implementation of the orchestrator service.
@@ -147,10 +148,10 @@ func TestPersistentFlags(t *testing.T) {
 	defer teardown()
 
 	mockOrch.On("Orchestrate", mock.MatchedBy(func(f model.Flags) bool {
-		return f.Region == "us-west-2" && f.Profile == "test-profile" && f.Output == "json"
+		return f.Region == "us-west-2" && f.Profile == "test-profile" && f.Output == outputJSON
 	})).Return(nil)
 
-	rootCmd.SetArgs([]string{"cost", "--region", "us-west-2", "--profile", "test-profile", "--output", "json"})
+	rootCmd.SetArgs([]string{"cost", "--region", "us-west-2", "--profile", "test-profile", "--output", outputJSON})
 
 	err := Execute(dev, none, unknown)
 	assert.NoError(t, err)
@@ -339,19 +340,25 @@ func TestExecuteWasteLambdaMemoryThresholdDefault(t *testing.T) {
 	mockOrch.AssertExpectations(t)
 }
 
-func TestBuildOrchestrator_NonTTY_DefaultsToJSON(t *testing.T) {
+// TestExecute_NonTTY_DefaultsToJSON verifies that PersistentPreRunE auto-selects JSON
+// when stdout is not a TTY and --output was not explicitly passed.
+func TestExecute_NonTTY_DefaultsToJSON(t *testing.T) {
 	if term.IsTerminal(int(os.Stdout.Fd())) {
 		t.Skip("skipping: stdout is a TTY, auto-detect does not apply")
 	}
 
-	outputFormat = table
+	mockOrch, teardown := setupTest()
+	defer teardown()
 
-	defer func() { outputFormat = table }()
+	mockOrch.On("Orchestrate", mock.MatchedBy(func(f model.Flags) bool {
+		return f.Waste == true && f.Output == outputJSON
+	})).Return(nil)
 
-	_, err := buildOrchestrator(false)
+	rootCmd.SetArgs([]string{"waste"})
 
+	err := Execute(dev, none, unknown)
 	assert.NoError(t, err)
-	assert.Equal(t, "json", outputFormat)
+	mockOrch.AssertExpectations(t)
 }
 
 func TestExecuteWaste_ExplicitTableOutput_Respected(t *testing.T) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -18,6 +18,7 @@ const (
 	dev     = "dev"
 	none    = "none"
 	unknown = "unknown"
+	table   = "table"
 )
 
 // MockOrchestrator is a mock implementation of the orchestrator service.
@@ -43,7 +44,7 @@ func setupTest() (*MockOrchestrator, func()) {
 		// Reset persistent flags to default values and changed state
 		region = ""
 		profile = ""
-		outputFormat = "table"
+		outputFormat = table
 		lambdaMemoryThreshold = 10
 		rootCmd.PersistentFlags().Lookup("output").Changed = false
 		rootCmd.PersistentFlags().Lookup("region").Changed = false
@@ -343,9 +344,9 @@ func TestBuildOrchestrator_NonTTY_DefaultsToJSON(t *testing.T) {
 		t.Skip("skipping: stdout is a TTY, auto-detect does not apply")
 	}
 
-	outputFormat = "table"
+	outputFormat = table
 
-	defer func() { outputFormat = "table" }()
+	defer func() { outputFormat = table }()
 
 	_, err := buildOrchestrator(false)
 
@@ -358,10 +359,10 @@ func TestExecuteWaste_ExplicitTableOutput_Respected(t *testing.T) {
 	defer teardown()
 
 	mockOrch.On("Orchestrate", mock.MatchedBy(func(f model.Flags) bool {
-		return f.Waste == true && f.Output == "table"
+		return f.Waste == true && f.Output == table
 	})).Return(nil)
 
-	rootCmd.SetArgs([]string{"waste", "--output", "table"})
+	rootCmd.SetArgs([]string{"waste", "--output", table})
 
 	err := Execute(dev, none, unknown)
 	assert.NoError(t, err)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/elC0mpa/aws-doctor/model"
 	"github.com/elC0mpa/aws-doctor/service/orchestrator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"golang.org/x/term"
 )
 
 const (
@@ -38,11 +40,14 @@ func setupTest() (*MockOrchestrator, func()) {
 
 	return mockOrch, func() {
 		orchestratorBuilder = originalBuilder
-		// Reset persistent flags to default
+		// Reset persistent flags to default values and changed state
 		region = ""
 		profile = ""
 		outputFormat = "table"
-		lambdaMemoryThreshold = 10 // reset to default
+		lambdaMemoryThreshold = 10
+		rootCmd.PersistentFlags().Lookup("output").Changed = false
+		rootCmd.PersistentFlags().Lookup("region").Changed = false
+		rootCmd.PersistentFlags().Lookup("profile").Changed = false
 	}
 }
 
@@ -327,6 +332,36 @@ func TestExecuteWasteLambdaMemoryThresholdDefault(t *testing.T) {
 	})).Return(nil)
 
 	rootCmd.SetArgs([]string{"waste"})
+
+	err := Execute(dev, none, unknown)
+	assert.NoError(t, err)
+	mockOrch.AssertExpectations(t)
+}
+
+func TestBuildOrchestrator_NonTTY_DefaultsToJSON(t *testing.T) {
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		t.Skip("skipping: stdout is a TTY, auto-detect does not apply")
+	}
+
+	outputFormat = "table"
+
+	defer func() { outputFormat = "table" }()
+
+	_, err := buildOrchestrator(false)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "json", outputFormat)
+}
+
+func TestExecuteWaste_ExplicitTableOutput_Respected(t *testing.T) {
+	mockOrch, teardown := setupTest()
+	defer teardown()
+
+	mockOrch.On("Orchestrate", mock.MatchedBy(func(f model.Flags) bool {
+		return f.Waste == true && f.Output == "table"
+	})).Return(nil)
+
+	rootCmd.SetArgs([]string{"waste", "--output", "table"})
 
 	err := Execute(dev, none, unknown)
 	assert.NoError(t, err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,10 +39,6 @@ var (
 )
 
 func buildOrchestrator(needsAWS bool) (orchestrator.Service, error) {
-	if !term.IsTerminal(int(os.Stdout.Fd())) && !rootCmd.PersistentFlags().Changed("output") {
-		outputFormat = "json"
-	}
-
 	outputService := output.NewService(outputFormat)
 	updateService := update.NewService(versionInfo)
 
@@ -56,8 +52,6 @@ func buildOrchestrator(needsAWS bool) (orchestrator.Service, error) {
 		return orchestrator.NewService(config), nil
 	}
 
-	banner.DrawBannerTitle()
-
 	cfgService := awsconfig.NewService()
 
 	awsCfg, err := cfgService.GetAWSCfg(context.Background(), region, profile)
@@ -65,6 +59,7 @@ func buildOrchestrator(needsAWS bool) (orchestrator.Service, error) {
 		return nil, fmt.Errorf("failed to load AWS config: %w", err)
 	}
 
+	banner.DrawBannerTitle()
 	spinner.StartSpinner()
 
 	cwMetricsService := cloudwatchmetrics.NewService(awsCfg)
@@ -105,6 +100,14 @@ func Execute(version, commit, date string) error {
 }
 
 func init() {
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		if !term.IsTerminal(int(os.Stdout.Fd())) && !rootCmd.PersistentFlags().Changed("output") {
+			outputFormat = "json"
+		}
+
+		return nil
+	}
+
 	rootCmd.PersistentFlags().StringVar(&region, "region", "", "AWS region (defaults to AWS_REGION, AWS_DEFAULT_REGION, or ~/.aws/config)")
 	rootCmd.PersistentFlags().StringVar(&profile, "profile", "", "AWS profile configuration")
 	rootCmd.PersistentFlags().StringVar(&outputFormat, "output", "table", "Output format: table, json or csv")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/elC0mpa/aws-doctor/model"
 	awsconfig "github.com/elC0mpa/aws-doctor/service/aws_config"
@@ -26,6 +27,7 @@ import (
 	"github.com/elC0mpa/aws-doctor/utils/banner"
 	"github.com/elC0mpa/aws-doctor/utils/spinner"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var (
@@ -37,6 +39,10 @@ var (
 )
 
 func buildOrchestrator(needsAWS bool) (orchestrator.Service, error) {
+	if !term.IsTerminal(int(os.Stdout.Fd())) && !rootCmd.PersistentFlags().Changed("output") {
+		outputFormat = "json"
+	}
+
 	outputService := output.NewService(outputFormat)
 	updateService := update.NewService(versionInfo)
 

--- a/utils/banner/banner.go
+++ b/utils/banner/banner.go
@@ -151,8 +151,14 @@ func bannerTitleColorName(color bannerColor) string {
 	return bannerTitleColorNames[int(color)]
 }
 
-// DrawBannerTitle prints the application title banner to stdout.
+// DrawBannerTitle prints the application title banner to stderr.
+// In non-TTY environments (pipes, AI tool calls) it prints a single short line instead.
 func DrawBannerTitle() {
+	if !term.IsTerminal(int(os.Stderr.Fd())) {
+		fmt.Fprintln(os.Stderr, "aws-doctor")
+		return
+	}
+
 	ansi.EnableANSI()
 
 	width := 80

--- a/utils/banner/banner_test.go
+++ b/utils/banner/banner_test.go
@@ -122,16 +122,6 @@ func TestPrintCenteredLines(t *testing.T) {
 	}
 }
 
-func TestDrawBannerTitle(t *testing.T) {
-	output := captureOutput(func() {
-		DrawBannerTitle()
-	})
-
-	if len(output) == 0 {
-		t.Error("DrawBannerTitle() produced no output")
-	}
-}
-
 func TestDrawBannerTitle_NonTerminal(t *testing.T) {
 	// When stderr is a pipe (non-TTY), only the short label should be printed.
 	output := captureOutput(func() {

--- a/utils/banner/banner_test.go
+++ b/utils/banner/banner_test.go
@@ -133,16 +133,13 @@ func TestDrawBannerTitle(t *testing.T) {
 }
 
 func TestDrawBannerTitle_NonTerminal(t *testing.T) {
-	// When stderr is a pipe, term.GetSize should fail
-	r, w, _ := os.Pipe()
-	oldStderr := os.Stderr
-	os.Stderr = w
+	// When stderr is a pipe (non-TTY), only the short label should be printed.
+	output := captureOutput(func() {
+		DrawBannerTitle()
+	})
 
-	// We don't use captureOutput here because we want to specifically
-	// have os.Stderr be a pipe during the term.GetSize call
-	DrawBannerTitle()
-
-	os.Stderr = oldStderr
-	_ = w.Close()
-	_ = r.Close()
+	const want = "aws-doctor\n"
+	if output != want {
+		t.Errorf("DrawBannerTitle() non-TTY output = %q, want %q", output, want)
+	}
 }

--- a/utils/spinner/spinner.go
+++ b/utils/spinner/spinner.go
@@ -5,12 +5,18 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	"golang.org/x/term"
 )
 
 var loader *spinner.Spinner
 
 // StartSpinner starts the CLI loading spinner.
+// In non-TTY environments the spinner is skipped — ANSI codes are meaningless there.
 func StartSpinner() {
+	if !term.IsTerminal(int(os.Stderr.Fd())) {
+		return
+	}
+
 	loader = spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
 	loader.Color("yellow") //nolint:errcheck
 	loader.Suffix = " Please wait while data is being fetched..."

--- a/utils/spinner/spinner_test.go
+++ b/utils/spinner/spinner_test.go
@@ -1,8 +1,11 @@
 package spinner
 
 import (
+	"os"
 	"testing"
 	"time"
+
+	"golang.org/x/term"
 )
 
 func TestStartAndStopSpinner(_ *testing.T) {
@@ -39,7 +42,10 @@ func TestSetMessage(t *testing.T) {
 }
 
 func TestStartSpinner_InitializesLoader(t *testing.T) {
-	// After calling StartSpinner, the global loader should be non-nil
+	if !term.IsTerminal(int(os.Stderr.Fd())) {
+		t.Skip("skipping: not a TTY, spinner is intentionally disabled in non-interactive mode")
+	}
+
 	StartSpinner()
 
 	defer StopSpinner()

--- a/utils/spinner/spinner_test.go
+++ b/utils/spinner/spinner_test.go
@@ -54,3 +54,17 @@ func TestStartSpinner_InitializesLoader(t *testing.T) {
 		t.Error("StartSpinner() did not initialize loader")
 	}
 }
+
+func TestStartSpinner_NonTTY_LoaderNil(t *testing.T) {
+	if term.IsTerminal(int(os.Stderr.Fd())) {
+		t.Skip("skipping: stderr is a TTY, spinner will be initialized")
+	}
+
+	loader = nil
+
+	StartSpinner()
+
+	if loader != nil {
+		t.Error("StartSpinner() should not initialize loader in non-TTY mode")
+	}
+}

--- a/utils/spinner/spinner_test.go
+++ b/utils/spinner/spinner_test.go
@@ -8,17 +8,21 @@ import (
 	"golang.org/x/term"
 )
 
-func TestStartAndStopSpinner(_ *testing.T) {
-	// Simple test to ensure it doesn't panic
-	// Note: We can't easily verify output since it writes to stdout/stderr directly
-	// and uses ANSI codes.
+func TestStartAndStopSpinner(t *testing.T) {
+	if !term.IsTerminal(int(os.Stderr.Fd())) {
+		t.Skip("skipping: not a TTY, spinner is intentionally disabled in non-interactive mode")
+	}
+
 	StartSpinner()
 	time.Sleep(100 * time.Millisecond)
 	StopSpinner()
 }
 
-func TestSpinnerSequence(_ *testing.T) {
-	// Test sequence of start, stop, start, stop
+func TestSpinnerSequence(t *testing.T) {
+	if !term.IsTerminal(int(os.Stderr.Fd())) {
+		t.Skip("skipping: not a TTY, spinner is intentionally disabled in non-interactive mode")
+	}
+
 	StartSpinner()
 	time.Sleep(50 * time.Millisecond)
 	StopSpinner()
@@ -60,7 +64,10 @@ func TestStartSpinner_NonTTY_LoaderNil(t *testing.T) {
 		t.Skip("skipping: stderr is a TTY, spinner will be initialized")
 	}
 
+	prev := loader
 	loader = nil
+
+	defer func() { loader = prev }()
 
 	StartSpinner()
 


### PR DESCRIPTION
## Description

When `aws-doctor` is invoked by an AI agent or automation tool (e.g. via MCP tool use or
a shell pipe), the full ASCII banner is visual noise and the default table output is
unparseable. This PR adds automatic non-interactive mode detection: if stdout is not a
terminal, the tool defaults to JSON output and suppresses the ASCII banner (replaced with
a single `aws-doctor` line to stderr), without requiring any extra flags.

**Behaviour summary:**

| Context | Banner | Default output |
|---|---|---|
| Interactive terminal | Full ASCII art | `table` |
| Pipe / AI tool call | `aws-doctor` (one line, stderr) | `json` |

An explicit `--output` flag always wins in both modes.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [x] 🐛 Fix (bug fix)
- [x] 🧹 Refactor (code improvement without functional changes)
- [x] 🧪 Test (adding or improving tests)

## ⚠️ Important: Target Branch
This PR targets the `development` branch.

## Checklist
- [x] I have rebased my branch against `upstream/development`.
- [x] My code follows the project's code style.
- [x] I have added unit tests to cover my changes.
- [ ] I have updated the documentation (if applicable).
- [x] All new and existing tests passed locally.

## Implementation details

- `rootCmd.PersistentPreRunE` — runs before every subcommand; sets `outputFormat = "json"` when stdout is non-TTY and `--output` was not explicitly passed
- `utils/banner/banner.go` — prints `"aws-doctor"` (one line) to stderr instead of the full ASCII art when stderr is non-TTY
- `utils/spinner/spinner.go` — skips spinner initialisation when stderr is non-TTY (ANSI codes are meaningless in that context)
- Banner is now drawn **after** AWS config loads successfully, so a config error no longer prints the banner before the error message

## Tests added

- `TestExecute_NonTTY_DefaultsToJSON` — end-to-end via `Execute()`, verifies `PersistentPreRunE` sets JSON as default in non-TTY
- `TestExecuteWaste_ExplicitTableOutput_Respected` — verifies explicit `--output table` is respected even in non-TTY (regression guard for the `Changed()` guard)
- `TestDrawBannerTitle_NonTerminal` — asserts stderr output is exactly `"aws-doctor\n"` in non-TTY
- `TestStartSpinner_NonTTY_LoaderNil` — asserts `loader` stays nil when stderr is non-TTY
- TTY-only tests (`TestStartAndStopSpinner`, `TestSpinnerSequence`) now skip in non-TTY instead of silently passing as no-ops