### PR TITLE
feat: surface public IPv4 address charges in EC2 waste analysis

### DIFF
--- a/mocks/services/ec2_service.go
+++ b/mocks/services/ec2_service.go
@@ -112,3 +112,13 @@ func (m *MockEC2Service) GetIdleInstances(ctx context.Context, idleDays int, cpu
 
 	return args.Get(0).([]model.EC2IdleInstanceInfo), args.Error(1)
 }
+
+// GetPublicIPv4Summary mocks the GetPublicIPv4Summary method.
+func (m *MockEC2Service) GetPublicIPv4Summary(ctx context.Context) (*model.PublicIPv4Summary, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*model.PublicIPv4Summary), args.Error(1)
+}

--- a/model/ec2.go
+++ b/model/ec2.go
@@ -90,6 +90,9 @@ type PublicIPv4Summary struct {
 // PublicIPv4RatePerHour is the AWS per-IP hourly charge (since Feb 2024).
 const PublicIPv4RatePerHour = 0.005
 
+// HoursPerMonth is the standard 730-hour billing month used by AWS for monthly cost estimates.
+const HoursPerMonth = 730.0
+
 // KeyPairWasteInfo contains information about unused EC2 key pairs
 type KeyPairWasteInfo struct {
 	KeyName         string

--- a/model/ec2.go
+++ b/model/ec2.go
@@ -66,6 +66,30 @@ type SnapshotWasteInfo struct {
 	MaxPotentialSavings float64          // Max monthly savings (actual may be lower due to incremental storage)
 }
 
+// PublicIPv4Summary reports the total count of in-use public IPv4 addresses
+// across EC2 instances, Elastic IPs, NAT Gateways, and ENIs, together with
+// the estimated hourly and monthly cost at the AWS per-IP rate.
+// Since February 2024 AWS charges $0.005/hr for every public IPv4 in use.
+type PublicIPv4Summary struct {
+	// TotalCount is the total number of public IPv4 addresses detected.
+	TotalCount int
+	// EC2InstanceIPs is the count from EC2 instances with a public IP.
+	EC2InstanceIPs int
+	// ElasticIPs is the count from allocated Elastic IP addresses (in use).
+	ElasticIPs int
+	// NatGatewayIPs is the count from NAT Gateway public IPs.
+	NatGatewayIPs int
+	// OtherENIIPs is the count from other ENIs (LBs, RDS, etc).
+	OtherENIIPs int
+	// HourlyCostUSD is estimated cost at $0.005 per IP per hour.
+	HourlyCostUSD float64
+	// MonthlyCostUSD is estimated cost per 730-hour month.
+	MonthlyCostUSD float64
+}
+
+// PublicIPv4RatePerHour is the AWS per-IP hourly charge (since Feb 2024).
+const PublicIPv4RatePerHour = 0.005
+
 // KeyPairWasteInfo contains information about unused EC2 key pairs
 type KeyPairWasteInfo struct {
 	KeyName         string

--- a/model/output.go
+++ b/model/output.go
@@ -51,6 +51,7 @@ type RenderWasteInput struct {
 	UnusedSecrets          []UnusedSecretInfo
 	UnusedIAMUsers         []IAMUserWasteInfo
 	RootUserWaste          []IAMRootUserWasteInfo
+	PublicIPv4Summary      *PublicIPv4Summary
 	Errors                 map[string]string
 }
 

--- a/service/ec2/service.go
+++ b/service/ec2/service.go
@@ -178,6 +178,22 @@ func (s *service) Analyze(ctx context.Context, flags model.Flags) (model.ScopeRe
 		return nil
 	})
 
+	// Retrieve public IPv4 address summary (in-use IPs and estimated charge).
+	g.Go(func() error {
+		ipv4Summary, err := s.GetPublicIPv4Summary(gCtx)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			input.PublicIPv4Summary = ipv4Summary
+		}
+
+		return nil
+	})
+
 	_ = g.Wait()
 
 	var finalErr error
@@ -757,4 +773,97 @@ func (s *service) getResourceTypeFromDescription(description string) types.Netwo
 	}
 
 	return types.NetworkInterfaceType("interface")
+}
+
+// GetPublicIPv4Summary returns an account-wide count of in-use public IPv4
+// addresses across EC2 instances, Elastic IPs, NAT Gateways, and other ENIs,
+// along with an estimated hourly and monthly cost.
+//
+// Since February 2024, AWS charges $0.005/hr for every public IPv4 in use,
+// not just unassociated Elastic IPs. This method surfaces that charge so
+// users can decide whether to migrate to IPv6 or private endpoints.
+func (s *service) GetPublicIPv4Summary(ctx context.Context) (*model.PublicIPv4Summary, error) {
+	summary := &model.PublicIPv4Summary{}
+
+	// 1. EC2 instances with a public IP.
+	instPaginator := ec2.NewDescribeInstancesPaginator(s.client, &ec2.DescribeInstancesInput{
+		Filters: []types.Filter{
+			{Name: aws.String("instance-state-name"), Values: []string{"running", "stopped"}},
+		},
+	})
+	for instPaginator.HasMorePages() {
+		page, err := instPaginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("describing instances for IPv4 summary: %w", err)
+		}
+		for _, res := range page.Reservations {
+			for _, inst := range res.Instances {
+				if inst.PublicIpAddress != nil && *inst.PublicIpAddress != "" {
+					summary.EC2InstanceIPs++
+				}
+			}
+		}
+	}
+
+	// 2. Elastic IPs (in-use only; unassociated EIPs are billed separately
+	//    and already surfaced by GetUnusedElasticIPAddressesInfo).
+	addrOutput, err := s.client.DescribeAddresses(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("describing addresses for IPv4 summary: %w", err)
+	}
+	for _, addr := range addrOutput.Addresses {
+		if addr.AssociationId != nil {
+			summary.ElasticIPs++
+		}
+	}
+
+	// 3. NAT Gateway public IPs.
+	natOutput, err := s.client.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+		Filter: []types.Filter{
+			{Name: aws.String("state"), Values: []string{"available", "pending"}},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describing NAT gateways for IPv4 summary: %w", err)
+	}
+	for _, ngw := range natOutput.NatGateways {
+		for _, addr := range ngw.NatGatewayAddresses {
+			if addr.PublicIp != nil && *addr.PublicIp != "" {
+				summary.NatGatewayIPs++
+			}
+		}
+	}
+
+	// 4. Other ENIs (LBs, RDS, EKS nodes, etc) — ENIs that have a public IP
+	//    via an association but are not covered by the EIP count above.
+	eniOutput, err := s.client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		Filters: []types.Filter{
+			{Name: aws.String("association.public-ip"), Values: []string{"*"}},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describing network interfaces for IPv4 summary: %w", err)
+	}
+	// Deduplicate: skip ENIs that are the backing interface for an EIP already counted.
+	eipENIs := make(map[string]struct{}, len(addrOutput.Addresses))
+	for _, addr := range addrOutput.Addresses {
+		if addr.NetworkInterfaceId != nil {
+			eipENIs[*addr.NetworkInterfaceId] = struct{}{}
+		}
+	}
+	for _, eni := range eniOutput.NetworkInterfaces {
+		if eni.Association == nil || eni.Association.PublicIp == nil {
+			continue
+		}
+		if _, isEIP := eipENIs[aws.ToString(eni.NetworkInterfaceId)]; isEIP {
+			continue
+		}
+		summary.OtherENIIPs++
+	}
+
+	summary.TotalCount = summary.EC2InstanceIPs + summary.ElasticIPs + summary.NatGatewayIPs + summary.OtherENIIPs
+	summary.HourlyCostUSD = float64(summary.TotalCount) * model.PublicIPv4RatePerHour
+	summary.MonthlyCostUSD = summary.HourlyCostUSD * 730
+
+	return summary, nil
 }

--- a/service/ec2/service.go
+++ b/service/ec2/service.go
@@ -783,8 +783,6 @@ func (s *service) getResourceTypeFromDescription(description string) types.Netwo
 // not just unassociated Elastic IPs. This method surfaces that charge so
 // users can decide whether to migrate to IPv6 or private endpoints.
 func (s *service) GetPublicIPv4Summary(ctx context.Context) (*model.PublicIPv4Summary, error) {
-	summary := &model.PublicIPv4Summary{}
-
 	// uniqueIPs deduplicates across all sources — an EC2 instance with an EIP,
 	// or a NAT GW whose EIP also shows in DescribeAddresses, must not be counted twice.
 	uniqueIPs := make(map[string]struct{})
@@ -793,25 +791,64 @@ func (s *service) GetPublicIPv4Summary(ctx context.Context) (*model.PublicIPv4Su
 	// exclude them from OtherENIIPs (auto-assigned public IPs would double-count).
 	instENIs := make(map[string]struct{})
 
-	// 1. EC2 instances with a public IP.
-	instPaginator := ec2.NewDescribeInstancesPaginator(s.client, &ec2.DescribeInstancesInput{
+	ec2Count, err := s.countEC2InstanceIPs(ctx, uniqueIPs, instENIs)
+	if err != nil {
+		return nil, err
+	}
+
+	eipCount, eipENIs, err := s.countElasticIPs(ctx, uniqueIPs)
+	if err != nil {
+		return nil, err
+	}
+
+	natCount, err := s.countNatGatewayIPs(ctx, uniqueIPs)
+	if err != nil {
+		return nil, err
+	}
+
+	eniCount, err := s.countOtherENIIPs(ctx, uniqueIPs, eipENIs, instENIs)
+	if err != nil {
+		return nil, err
+	}
+
+	summary := &model.PublicIPv4Summary{
+		EC2InstanceIPs: ec2Count,
+		ElasticIPs:     eipCount,
+		NatGatewayIPs:  natCount,
+		OtherENIIPs:    eniCount,
+		TotalCount:     len(uniqueIPs),
+	}
+
+	summary.HourlyCostUSD = float64(summary.TotalCount) * model.PublicIPv4RatePerHour
+	summary.MonthlyCostUSD = summary.HourlyCostUSD * model.HoursPerMonth
+
+	return summary, nil
+}
+
+func (s *service) countEC2InstanceIPs(ctx context.Context, uniqueIPs, instENIs map[string]struct{}) (int, error) {
+	count := 0
+
+	paginator := ec2.NewDescribeInstancesPaginator(s.client, &ec2.DescribeInstancesInput{
 		Filters: []types.Filter{
 			{Name: aws.String("instance-state-name"), Values: []string{"running", "stopped"}},
 		},
 	})
-	for instPaginator.HasMorePages() {
-		page, err := instPaginator.NextPage(ctx)
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("describing instances for IPv4 summary: %w", err)
+			return 0, fmt.Errorf("describing instances for IPv4 summary: %w", err)
 		}
+
 		for _, res := range page.Reservations {
 			for _, inst := range res.Instances {
 				if inst.PublicIpAddress != nil && *inst.PublicIpAddress != "" {
 					if _, seen := uniqueIPs[*inst.PublicIpAddress]; !seen {
 						uniqueIPs[*inst.PublicIpAddress] = struct{}{}
-						summary.EC2InstanceIPs++
+						count++
 					}
 				}
+
 				for _, ni := range inst.NetworkInterfaces {
 					if ni.NetworkInterfaceId != nil {
 						instENIs[*ni.NetworkInterfaceId] = struct{}{}
@@ -821,85 +858,104 @@ func (s *service) GetPublicIPv4Summary(ctx context.Context) (*model.PublicIPv4Su
 		}
 	}
 
-	// 2. Elastic IPs (in-use only; unassociated EIPs are billed separately
-	//    and already surfaced by GetUnusedElasticIPAddressesInfo).
+	return count, nil
+}
+
+func (s *service) countElasticIPs(ctx context.Context, uniqueIPs map[string]struct{}) (int, map[string]struct{}, error) {
 	addrOutput, err := s.client.DescribeAddresses(ctx, nil)
 	if err != nil {
-		return nil, fmt.Errorf("describing addresses for IPv4 summary: %w", err)
+		return 0, nil, fmt.Errorf("describing addresses for IPv4 summary: %w", err)
 	}
+
+	count := 0
 	eipENIs := make(map[string]struct{}, len(addrOutput.Addresses))
+
 	for _, addr := range addrOutput.Addresses {
 		if addr.AssociationId == nil {
 			continue
 		}
+
 		if addr.PublicIp != nil && *addr.PublicIp != "" {
 			if _, seen := uniqueIPs[*addr.PublicIp]; !seen {
 				uniqueIPs[*addr.PublicIp] = struct{}{}
-				summary.ElasticIPs++
+				count++
 			}
 		}
+
 		if addr.NetworkInterfaceId != nil {
 			eipENIs[*addr.NetworkInterfaceId] = struct{}{}
 		}
 	}
 
-	// 3. NAT Gateway public IPs — paginated for large accounts.
-	natPaginator := ec2.NewDescribeNatGatewaysPaginator(s.client, &ec2.DescribeNatGatewaysInput{
+	return count, eipENIs, nil
+}
+
+func (s *service) countNatGatewayIPs(ctx context.Context, uniqueIPs map[string]struct{}) (int, error) {
+	count := 0
+
+	paginator := ec2.NewDescribeNatGatewaysPaginator(s.client, &ec2.DescribeNatGatewaysInput{
 		Filter: []types.Filter{
 			{Name: aws.String("state"), Values: []string{"available", "pending"}},
 		},
 	})
-	for natPaginator.HasMorePages() {
-		page, err := natPaginator.NextPage(ctx)
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("describing NAT gateways for IPv4 summary: %w", err)
+			return 0, fmt.Errorf("describing NAT gateways for IPv4 summary: %w", err)
 		}
+
 		for _, ngw := range page.NatGateways {
 			for _, addr := range ngw.NatGatewayAddresses {
 				if addr.PublicIp != nil && *addr.PublicIp != "" {
 					if _, seen := uniqueIPs[*addr.PublicIp]; !seen {
 						uniqueIPs[*addr.PublicIp] = struct{}{}
-						summary.NatGatewayIPs++
+						count++
 					}
 				}
 			}
 		}
 	}
 
-	// 4. Other ENIs (LBs, RDS, EKS nodes, etc) — paginated; skip ENIs already
-	//    counted via EIPs (step 2) or EC2 instance interfaces (step 1).
-	eniPaginator := ec2.NewDescribeNetworkInterfacesPaginator(s.client, &ec2.DescribeNetworkInterfacesInput{
+	return count, nil
+}
+
+func (s *service) countOtherENIIPs(ctx context.Context, uniqueIPs, eipENIs, instENIs map[string]struct{}) (int, error) {
+	count := 0
+
+	paginator := ec2.NewDescribeNetworkInterfacesPaginator(s.client, &ec2.DescribeNetworkInterfacesInput{
 		Filters: []types.Filter{
 			{Name: aws.String("association.public-ip"), Values: []string{"*"}},
 		},
 	})
-	for eniPaginator.HasMorePages() {
-		page, err := eniPaginator.NextPage(ctx)
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("describing network interfaces for IPv4 summary: %w", err)
+			return 0, fmt.Errorf("describing network interfaces for IPv4 summary: %w", err)
 		}
+
 		for _, eni := range page.NetworkInterfaces {
 			if eni.Association == nil || eni.Association.PublicIp == nil {
 				continue
 			}
+
 			eniID := aws.ToString(eni.NetworkInterfaceId)
 			if _, isEIP := eipENIs[eniID]; isEIP {
 				continue
 			}
+
 			if _, isInst := instENIs[eniID]; isInst {
 				continue
 			}
+
 			ip := *eni.Association.PublicIp
 			if _, seen := uniqueIPs[ip]; !seen {
 				uniqueIPs[ip] = struct{}{}
-				summary.OtherENIIPs++
+				count++
 			}
 		}
 	}
 
-	summary.TotalCount = len(uniqueIPs)
-	summary.HourlyCostUSD = float64(summary.TotalCount) * model.PublicIPv4RatePerHour
-	summary.MonthlyCostUSD = summary.HourlyCostUSD * model.HoursPerMonth
-
-	return summary, nil
+	return count, nil
 }

--- a/service/ec2/service.go
+++ b/service/ec2/service.go
@@ -785,6 +785,14 @@ func (s *service) getResourceTypeFromDescription(description string) types.Netwo
 func (s *service) GetPublicIPv4Summary(ctx context.Context) (*model.PublicIPv4Summary, error) {
 	summary := &model.PublicIPv4Summary{}
 
+	// uniqueIPs deduplicates across all sources — an EC2 instance with an EIP,
+	// or a NAT GW whose EIP also shows in DescribeAddresses, must not be counted twice.
+	uniqueIPs := make(map[string]struct{})
+
+	// instENIs collects every ENI attached to an EC2 instance so step 4 can
+	// exclude them from OtherENIIPs (auto-assigned public IPs would double-count).
+	instENIs := make(map[string]struct{})
+
 	// 1. EC2 instances with a public IP.
 	instPaginator := ec2.NewDescribeInstancesPaginator(s.client, &ec2.DescribeInstancesInput{
 		Filters: []types.Filter{
@@ -799,7 +807,15 @@ func (s *service) GetPublicIPv4Summary(ctx context.Context) (*model.PublicIPv4Su
 		for _, res := range page.Reservations {
 			for _, inst := range res.Instances {
 				if inst.PublicIpAddress != nil && *inst.PublicIpAddress != "" {
-					summary.EC2InstanceIPs++
+					if _, seen := uniqueIPs[*inst.PublicIpAddress]; !seen {
+						uniqueIPs[*inst.PublicIpAddress] = struct{}{}
+						summary.EC2InstanceIPs++
+					}
+				}
+				for _, ni := range inst.NetworkInterfaces {
+					if ni.NetworkInterfaceId != nil {
+						instENIs[*ni.NetworkInterfaceId] = struct{}{}
+					}
 				}
 			}
 		}
@@ -811,59 +827,79 @@ func (s *service) GetPublicIPv4Summary(ctx context.Context) (*model.PublicIPv4Su
 	if err != nil {
 		return nil, fmt.Errorf("describing addresses for IPv4 summary: %w", err)
 	}
-	for _, addr := range addrOutput.Addresses {
-		if addr.AssociationId != nil {
-			summary.ElasticIPs++
-		}
-	}
-
-	// 3. NAT Gateway public IPs.
-	natOutput, err := s.client.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
-		Filter: []types.Filter{
-			{Name: aws.String("state"), Values: []string{"available", "pending"}},
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("describing NAT gateways for IPv4 summary: %w", err)
-	}
-	for _, ngw := range natOutput.NatGateways {
-		for _, addr := range ngw.NatGatewayAddresses {
-			if addr.PublicIp != nil && *addr.PublicIp != "" {
-				summary.NatGatewayIPs++
-			}
-		}
-	}
-
-	// 4. Other ENIs (LBs, RDS, EKS nodes, etc) — ENIs that have a public IP
-	//    via an association but are not covered by the EIP count above.
-	eniOutput, err := s.client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
-		Filters: []types.Filter{
-			{Name: aws.String("association.public-ip"), Values: []string{"*"}},
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("describing network interfaces for IPv4 summary: %w", err)
-	}
-	// Deduplicate: skip ENIs that are the backing interface for an EIP already counted.
 	eipENIs := make(map[string]struct{}, len(addrOutput.Addresses))
 	for _, addr := range addrOutput.Addresses {
+		if addr.AssociationId == nil {
+			continue
+		}
+		if addr.PublicIp != nil && *addr.PublicIp != "" {
+			if _, seen := uniqueIPs[*addr.PublicIp]; !seen {
+				uniqueIPs[*addr.PublicIp] = struct{}{}
+				summary.ElasticIPs++
+			}
+		}
 		if addr.NetworkInterfaceId != nil {
 			eipENIs[*addr.NetworkInterfaceId] = struct{}{}
 		}
 	}
-	for _, eni := range eniOutput.NetworkInterfaces {
-		if eni.Association == nil || eni.Association.PublicIp == nil {
-			continue
+
+	// 3. NAT Gateway public IPs — paginated for large accounts.
+	natPaginator := ec2.NewDescribeNatGatewaysPaginator(s.client, &ec2.DescribeNatGatewaysInput{
+		Filter: []types.Filter{
+			{Name: aws.String("state"), Values: []string{"available", "pending"}},
+		},
+	})
+	for natPaginator.HasMorePages() {
+		page, err := natPaginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("describing NAT gateways for IPv4 summary: %w", err)
 		}
-		if _, isEIP := eipENIs[aws.ToString(eni.NetworkInterfaceId)]; isEIP {
-			continue
+		for _, ngw := range page.NatGateways {
+			for _, addr := range ngw.NatGatewayAddresses {
+				if addr.PublicIp != nil && *addr.PublicIp != "" {
+					if _, seen := uniqueIPs[*addr.PublicIp]; !seen {
+						uniqueIPs[*addr.PublicIp] = struct{}{}
+						summary.NatGatewayIPs++
+					}
+				}
+			}
 		}
-		summary.OtherENIIPs++
 	}
 
-	summary.TotalCount = summary.EC2InstanceIPs + summary.ElasticIPs + summary.NatGatewayIPs + summary.OtherENIIPs
+	// 4. Other ENIs (LBs, RDS, EKS nodes, etc) — paginated; skip ENIs already
+	//    counted via EIPs (step 2) or EC2 instance interfaces (step 1).
+	eniPaginator := ec2.NewDescribeNetworkInterfacesPaginator(s.client, &ec2.DescribeNetworkInterfacesInput{
+		Filters: []types.Filter{
+			{Name: aws.String("association.public-ip"), Values: []string{"*"}},
+		},
+	})
+	for eniPaginator.HasMorePages() {
+		page, err := eniPaginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("describing network interfaces for IPv4 summary: %w", err)
+		}
+		for _, eni := range page.NetworkInterfaces {
+			if eni.Association == nil || eni.Association.PublicIp == nil {
+				continue
+			}
+			eniID := aws.ToString(eni.NetworkInterfaceId)
+			if _, isEIP := eipENIs[eniID]; isEIP {
+				continue
+			}
+			if _, isInst := instENIs[eniID]; isInst {
+				continue
+			}
+			ip := *eni.Association.PublicIp
+			if _, seen := uniqueIPs[ip]; !seen {
+				uniqueIPs[ip] = struct{}{}
+				summary.OtherENIIPs++
+			}
+		}
+	}
+
+	summary.TotalCount = len(uniqueIPs)
 	summary.HourlyCostUSD = float64(summary.TotalCount) * model.PublicIPv4RatePerHour
-	summary.MonthlyCostUSD = summary.HourlyCostUSD * 730
+	summary.MonthlyCostUSD = summary.HourlyCostUSD * model.HoursPerMonth
 
 	return summary, nil
 }

--- a/service/ec2/types.go
+++ b/service/ec2/types.go
@@ -19,6 +19,7 @@ type ClientAPI interface {
 	DescribeImages(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error)
 	DescribeSnapshots(ctx context.Context, params *ec2.DescribeSnapshotsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSnapshotsOutput, error)
 	DescribeKeyPairs(ctx context.Context, params *ec2.DescribeKeyPairsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeKeyPairsOutput, error)
+	DescribeNatGateways(ctx context.Context, params *ec2.DescribeNatGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNatGatewaysOutput, error)
 }
 
 type service struct {
@@ -51,4 +52,5 @@ type Service interface {
 	GetOrphanedSnapshots(ctx context.Context, staleDays int) ([]model.SnapshotWasteInfo, error)
 	GetUnusedKeyPairs(ctx context.Context) ([]model.KeyPairWasteInfo, error)
 	GetIdleInstances(ctx context.Context, idleDays int, cpuThresholdPercent float64, networkBytesPerDayThreshold float64) ([]model.EC2IdleInstanceInfo, error)
+	GetPublicIPv4Summary(ctx context.Context) (*model.PublicIPv4Summary, error)
 }


### PR DESCRIPTION
## Summary
- Adds detection and reporting of public IPv4 address charges in EC2 waste analysis
- Surfaces cost impact of allocated public IPv4 addresses to help users identify unnecessary spend

## Test plan
- [ ] Run EC2 waste analysis against an AWS account with public IPv4 addresses
- [ ] Verify public IPv4 charges appear in output
- [ ] Verify accounts without public IPv4 addresses show no change in output